### PR TITLE
internal/authz: retain strings as arguments when reducing SQL ASTs

### DIFF
--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -3,6 +3,7 @@ package authz
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -66,7 +67,9 @@ func TestPartial(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			rows, err := db.Query("SELECT * FROM sources WHERE " + result.SQL())
+			cond, args := result.SQL(func(int) string { return "?" }, nil)
+			fmt.Println("cond:", cond, "args:", args)
+			rows, err := db.Query("SELECT * FROM sources WHERE "+cond, args...)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This commit improves the authz package to retain string values as arguments when reducing the SQL ASTs before splicing them into DB queries. This ensures that any string values returned by PE can be properly escpaed by the DB driver.