### PR TITLE
internal/database: Set the minimum TLS version 1.2.

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -216,7 +216,8 @@ func (d *Database) InitDB(ctx context.Context) error {
 				}
 
 				mysqldriver.RegisterTLSConfig("custom", &tls.Config{
-					RootCAs: rootCertPool,
+					RootCAs:    rootCertPool,
+					MinVersion: tls.VersionTLS12,
 				})
 				tlsConfigName = "custom"
 			}


### PR DESCRIPTION
This way no need to rely indirectly on the golang runtime version.