### PR TITLE
Update README example to make OPA explicitly read files as bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ In your working directory run the `build` command:
 You could set up a simple server to serve up the bundle, but for now we can just use OPA to watch the bundle.  Run this in your working directory:
 
 ```shell
-opa run -s -w ./bundles/hello-world/bundle.tar.gz
+opa run -s -b -w ./bundles/hello-world/bundle.tar.gz
 ```
 
 ## 5. Test the policy


### PR DESCRIPTION
Some OPA versions have a halting [bug](https://github.com/open-policy-agent/opa/issues/7870) when watching bundles and bundle-mode isn't explicit. Using the `-b` flag avoids a panic on bundle reload.