### PR TITLE
internal/gitsync: Use HTTP basic auth with GitHub App's git access.

### DIFF
--- a/internal/gitsync/gitsync.go
+++ b/internal/gitsync/gitsync.go
@@ -158,7 +158,7 @@ func (s *Synchronizer) auth(ctx context.Context) (transport.AuthMethod, error) {
 			return nil, err
 		}
 
-		return &http.TokenAuth{Token: token}, nil
+		return &http.BasicAuth{Username: "x-access-token", Password: token}, nil
 
 	case config.SecretSSHKey:
 		return newSSHAuth(value.Key, value.Passphrase, value.Fingerprints)


### PR DESCRIPTION
Unlike most of the GitHub REST APIs, the git access does not accept Installation Access Tokens (UATs) as such but they must be used as a HTTP basic auth password.