### PR TITLE
 internal/gitsync: If configuration changes, wipe the clone.

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -22,7 +22,7 @@ Example:
 ```yaml
 tokens:
     admin:
-        api-key: 7lPLBKKpmiljMa0J9GwyYWLDJKEVFXEO6ZGAjmDf5eQ=
+        api_key: 7lPLBKKpmiljMa0J9GwyYWLDJKEVFXEO6ZGAjmDf5eQ=
         scopes:
             - role: administrator
 ```


### PR DESCRIPTION
Cloned repository holds the origin information and reconfiguring the URL should trigger re-cloning. However, instead of blindly wiping the cloned repositories during boot or reconfiguration, persist the configuration to filesystem and detect the configuration changes to avoid unnecessary wiping, and therefore, cloning.