### PR TITLE
tests: run server tests with multiple databases

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -10,146 +10,171 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/testcontainers/testcontainers-go"
+
 	"github.com/styrainc/opa-control-plane/internal/config"
 	"github.com/styrainc/opa-control-plane/internal/database"
 	"github.com/styrainc/opa-control-plane/internal/server/types"
+	"github.com/styrainc/opa-control-plane/internal/test/dbs"
 )
 
 func TestServerSourcesData(t *testing.T) {
-	ctx := context.Background()
-	db := initTestDB(ctx, t)
-	ts := initTestServer(t, db)
-	defer ts.Close()
+	ctx := t.Context()
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				t.Cleanup(databaseConfig.Cleanup(t, ctr))
+			}
 
-	if err := db.UpsertPrincipal(ctx, database.Principal{Id: "internaladmin", Role: "administrator"}); err != nil {
-		t.Fatal(err)
-	}
+			db := (&database.Database{}).WithConfig(databaseConfig.Database(t, ctr).Database)
+			db = initTestDB(t, db)
+			ts := initTestServer(t, db)
+			defer ts.Close()
 
-	const adminKey = "test-admin-apikey"
+			if err := db.UpsertPrincipal(ctx, database.Principal{Id: "internaladmin", Role: "administrator"}); err != nil {
+				t.Fatal(err)
+			}
 
-	if err := db.UpsertToken(ctx, "internaladmin", &config.Token{Name: "admin", APIKey: adminKey, Scopes: []config.Scope{{Role: "administrator"}}}); err != nil {
-		t.Fatal(err)
-	}
+			const adminKey = "test-admin-apikey"
 
-	tests := []struct {
-		name       string
-		method     string
-		path       string
-		body       string
-		apikey     string
-		statusCode int
-		result     string
-	}{
-		{
-			name:       "Create source",
-			method:     "PUT",
-			path:       "/v1/sources/system1",
-			body:       `{}`,
-			apikey:     adminKey,
-			statusCode: 200,
-			result:     "{}\n",
-		},
-		{
-			name:       "GET",
-			method:     "GET",
-			path:       "/v1/sources/system1/data/foo",
-			body:       "",
-			apikey:     adminKey,
-			statusCode: 200,
-			result:     "{}\n",
-		},
-		{
-			name:       "PUT",
-			method:     "PUT",
-			path:       "/v1/sources/system1/data/foo",
-			body:       `{"key": "value"}`,
-			apikey:     adminKey,
-			statusCode: 200,
-			result:     "{}\n",
-		},
-		{
-			name:       "GET after PUT",
-			method:     "GET",
-			path:       "/v1/sources/system1/data/foo",
-			body:       "",
-			apikey:     adminKey,
-			statusCode: 200,
-			result: `{"result":{"key":"value"}}
+			if err := db.UpsertToken(ctx, "internaladmin", &config.Token{Name: "admin", APIKey: adminKey, Scopes: []config.Scope{{Role: "administrator"}}}); err != nil {
+				t.Fatal(err)
+			}
+
+			tests := []struct {
+				name       string
+				method     string
+				path       string
+				body       string
+				apikey     string
+				statusCode int
+				result     string
+			}{
+				{
+					name:       "Create source",
+					method:     "PUT",
+					path:       "/v1/sources/system1",
+					body:       `{}`,
+					apikey:     adminKey,
+					statusCode: 200,
+					result:     "{}\n",
+				},
+				{
+					name:       "GET",
+					method:     "GET",
+					path:       "/v1/sources/system1/data/foo",
+					body:       "",
+					apikey:     adminKey,
+					statusCode: 200,
+					result:     "{}\n",
+				},
+				{
+					name:       "PUT",
+					method:     "PUT",
+					path:       "/v1/sources/system1/data/foo",
+					body:       `{"key": "value"}`,
+					apikey:     adminKey,
+					statusCode: 200,
+					result:     "{}\n",
+				},
+				{
+					name:       "GET after PUT",
+					method:     "GET",
+					path:       "/v1/sources/system1/data/foo",
+					body:       "",
+					apikey:     adminKey,
+					statusCode: 200,
+					result: `{"result":{"key":"value"}}
 `,
-		},
-		{
-			name:       "POST",
-			method:     "POST",
-			path:       "/v1/sources/system1/data/foo",
-			body:       `{"key": "value2"}`,
-			apikey:     adminKey,
-			statusCode: 200,
-			result:     "{}\n",
-		},
-		{
-			name:       "GET after POST",
-			method:     "GET",
-			path:       "/v1/sources/system1/data/foo",
-			body:       "",
-			apikey:     adminKey,
-			statusCode: 200,
-			result: `{"result":{"key":"value2"}}
+				},
+				{
+					name:       "POST",
+					method:     "POST",
+					path:       "/v1/sources/system1/data/foo",
+					body:       `{"key": "value2"}`,
+					apikey:     adminKey,
+					statusCode: 200,
+					result:     "{}\n",
+				},
+				{
+					name:       "GET after POST",
+					method:     "GET",
+					path:       "/v1/sources/system1/data/foo",
+					body:       "",
+					apikey:     adminKey,
+					statusCode: 200,
+					result: `{"result":{"key":"value2"}}
 `,
-		},
-		{
-			name:       "DELETE",
-			method:     "DELETE",
-			path:       "/v1/sources/system1/data/foo",
-			body:       "",
-			apikey:     adminKey,
-			statusCode: 200,
-			result:     "{}\n",
-		},
-		{
-			name:       "GET after DELETE",
-			method:     "GET",
-			path:       "/v1/sources/system1/data/foo",
-			body:       "",
-			apikey:     adminKey,
-			statusCode: 200,
-			result:     "{}\n",
-		},
-	}
+				},
+				{
+					name:       "DELETE",
+					method:     "DELETE",
+					path:       "/v1/sources/system1/data/foo",
+					body:       "",
+					apikey:     adminKey,
+					statusCode: 200,
+					result:     "{}\n",
+				},
+				{
+					name:       "GET after DELETE",
+					method:     "GET",
+					path:       "/v1/sources/system1/data/foo",
+					body:       "",
+					apikey:     adminKey,
+					statusCode: 200,
+					result:     "{}\n",
+				},
+			}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			tr := ts.Request(test.method, test.path, test.body, test.apikey).ExpectStatus(test.statusCode)
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					tr := ts.Request(test.method, test.path, test.body, test.apikey).ExpectStatus(test.statusCode)
 
-			if tr.Body().String() != test.result {
-				t.Fatalf("expected body %q, got %q", test.result, tr.Body().String())
+					if tr.Body().String() != test.result {
+						t.Fatalf("expected body %q, got %q", test.result, tr.Body().String())
+					}
+				})
 			}
 		})
 	}
 }
 
 func TestServerBundleOwners(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
-	db := initTestDB(ctx, t)
-	ts := initTestServer(t, db)
-	defer ts.Close()
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				t.Cleanup(databaseConfig.Cleanup(t, ctr))
+			}
 
-	if err := db.UpsertPrincipal(ctx, database.Principal{Id: "internal", Role: "administrator"}); err != nil {
-		t.Fatal(err)
-	}
+			db := (&database.Database{}).WithConfig(databaseConfig.Database(t, ctr).Database)
+			db = initTestDB(t, db)
+			ts := initTestServer(t, db)
+			defer ts.Close()
 
-	const ownerKey = "test-owner-key"
-	const ownerKey2 = "test-owner-key2"
+			if err := db.UpsertPrincipal(ctx, database.Principal{Id: "internal", Role: "administrator"}); err != nil {
+				t.Fatal(err)
+			}
 
-	if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "testowner", APIKey: ownerKey, Scopes: []config.Scope{{Role: "owner"}}}); err != nil {
-		t.Fatal(err)
-	}
+			const ownerKey = "test-owner-key"
+			const ownerKey2 = "test-owner-key2"
 
-	if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "testowner2", APIKey: ownerKey2, Scopes: []config.Scope{{Role: "owner"}}}); err != nil {
-		t.Fatal(err)
-	}
+			if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "testowner", APIKey: ownerKey, Scopes: []config.Scope{{Role: "owner"}}}); err != nil {
+				t.Fatal(err)
+			}
 
-	ts.Request("PUT", "/v1/bundles/testbundle", `{
+			if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "testowner2", APIKey: ownerKey2, Scopes: []config.Scope{{Role: "owner"}}}); err != nil {
+				t.Fatal(err)
+			}
+
+			ts.Request("PUT", "/v1/bundles/testbundle", `{
 		"object_storage": {
 			"aws": {
 				"region": "us-east-1",
@@ -159,191 +184,229 @@ func TestServerBundleOwners(t *testing.T) {
 		}
 	}`, ownerKey).ExpectStatus(200)
 
-	var ownerList types.BundlesListResponseV1
-	ts.Request("GET", "/v1/bundles", "", ownerKey).ExpectStatus(200).ExpectBody(&ownerList)
-	if len(ownerList.Result) != 1 {
-		t.Fatal("expected exactly one bundle")
+			var ownerList types.BundlesListResponseV1
+			ts.Request("GET", "/v1/bundles", "", ownerKey).ExpectStatus(200).ExpectBody(&ownerList)
+			if len(ownerList.Result) != 1 {
+				t.Fatal("expected exactly one bundle")
+			}
+
+			var bundle types.BundlesGetResponseV1
+			ts.Request("GET", "/v1/bundles/testbundle", "", ownerKey).ExpectStatus(200).ExpectBody(&bundle)
+
+			if !bundle.Result.Equal(&config.Bundle{
+				ObjectStorage: config.ObjectStorage{
+					AmazonS3: &config.AmazonS3{
+						Region: "us-east-1",
+						Bucket: "test-bucket",
+						Key:    "test-key",
+					},
+				},
+			}) {
+				t.Fatal("expected bundle to be populated")
+			}
+
+			var ownerList2 types.SourcesListResponseV1
+			ts.Request("GET", "/v1/bundles", "", ownerKey2).ExpectStatus(200).ExpectBody(&ownerList2)
+			if len(ownerList2.Result) != 0 {
+				t.Fatal("did not expect to see source")
+			}
+
+			ts.Request("PUT", "/v1/bundles/testbundle", "{}", ownerKey2).ExpectStatus(403)
+			ts.Request("GET", "/v1/bundles/testbundle", "", ownerKey2).ExpectStatus(404)
+			ts.Request("PUT", "/v1/bundles/testbundle", "{}", ownerKey).ExpectStatus(200)
+		})
 	}
-
-	var bundle types.BundlesGetResponseV1
-	ts.Request("GET", "/v1/bundles/testbundle", "", ownerKey).ExpectStatus(200).ExpectBody(&bundle)
-
-	if !bundle.Result.Equal(&config.Bundle{
-		ObjectStorage: config.ObjectStorage{
-			AmazonS3: &config.AmazonS3{
-				Region: "us-east-1",
-				Bucket: "test-bucket",
-				Key:    "test-key",
-			},
-		},
-	}) {
-		t.Fatal("expected bundle to be populated")
-	}
-
-	var ownerList2 types.SourcesListResponseV1
-	ts.Request("GET", "/v1/bundles", "", ownerKey2).ExpectStatus(200).ExpectBody(&ownerList2)
-	if len(ownerList2.Result) != 0 {
-		t.Fatal("did not expect to see source")
-	}
-
-	ts.Request("PUT", "/v1/bundles/testbundle", "{}", ownerKey2).ExpectStatus(403)
-	ts.Request("GET", "/v1/bundles/testbundle", "", ownerKey2).ExpectStatus(404)
-	ts.Request("PUT", "/v1/bundles/testbundle", "{}", ownerKey).ExpectStatus(200)
 }
 
 func TestServerSourceOwners(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				t.Cleanup(databaseConfig.Cleanup(t, ctr))
+			}
 
-	db := initTestDB(ctx, t)
-	ts := initTestServer(t, db)
-	defer ts.Close()
+			db := (&database.Database{}).WithConfig(databaseConfig.Database(t, ctr).Database)
+			db = initTestDB(t, db)
 
-	if err := db.UpsertPrincipal(ctx, database.Principal{Id: "internal", Role: "administrator"}); err != nil {
-		t.Fatal(err)
+			ts := initTestServer(t, db)
+			defer ts.Close()
+
+			if err := db.UpsertPrincipal(ctx, database.Principal{Id: "internal", Role: "administrator"}); err != nil {
+				t.Fatal(err)
+			}
+
+			const ownerKey = "test-owner-key"
+			const ownerKey2 = "test-owner-key2"
+
+			if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "testowner", APIKey: ownerKey, Scopes: []config.Scope{{Role: "owner"}}}); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "testowner2", APIKey: ownerKey2, Scopes: []config.Scope{{Role: "owner"}}}); err != nil {
+				t.Fatal(err)
+			}
+
+			ts.Request("PUT", "/v1/sources/testsrc", `{"datasources": [{"name": "ds"}]}`, ownerKey).ExpectStatus(200)
+
+			var ownerList types.SourcesListResponseV1
+			ts.Request("GET", "/v1/sources", "", ownerKey).ExpectStatus(200).ExpectBody(&ownerList)
+			if len(ownerList.Result) != 1 {
+				t.Fatal("expected exactly one source")
+			}
+
+			var src types.SourcesGetResponseV1
+			ts.Request("GET", "/v1/sources/testsrc", "", ownerKey).ExpectStatus(200).ExpectBody(&src)
+			if !src.Result.Equal(&config.Source{
+				Datasources: []config.Datasource{
+					{Name: "ds"},
+				},
+			}) {
+				t.Fatal("expected source to be populated")
+			}
+
+			var ownerList2 types.SourcesListResponseV1
+			ts.Request("GET", "/v1/sources", "", ownerKey2).ExpectStatus(200).ExpectBody(&ownerList2)
+			if len(ownerList2.Result) != 0 {
+				t.Fatal("did not expect to see source")
+			}
+
+			ts.Request("PUT", "/v1/sources/testsrc", "{}", ownerKey2).ExpectStatus(403)
+			ts.Request("GET", "/v1/sources/testsrc", "", ownerKey2).ExpectStatus(404)
+			ts.Request("PUT", "/v1/sources/testsrc", "{}", ownerKey).ExpectStatus(200)
+		})
 	}
-
-	const ownerKey = "test-owner-key"
-	const ownerKey2 = "test-owner-key2"
-
-	if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "testowner", APIKey: ownerKey, Scopes: []config.Scope{{Role: "owner"}}}); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "testowner2", APIKey: ownerKey2, Scopes: []config.Scope{{Role: "owner"}}}); err != nil {
-		t.Fatal(err)
-	}
-
-	ts.Request("PUT", "/v1/sources/testsrc", `{"datasources": [{"name": "ds"}]}`, ownerKey).ExpectStatus(200)
-
-	var ownerList types.SourcesListResponseV1
-	ts.Request("GET", "/v1/sources", "", ownerKey).ExpectStatus(200).ExpectBody(&ownerList)
-	if len(ownerList.Result) != 1 {
-		t.Fatal("expected exactly one source")
-	}
-
-	var src types.SourcesGetResponseV1
-	ts.Request("GET", "/v1/sources/testsrc", "", ownerKey).ExpectStatus(200).ExpectBody(&src)
-	if !src.Result.Equal(&config.Source{
-		Datasources: []config.Datasource{
-			{Name: "ds"},
-		},
-	}) {
-		t.Fatal("expected source to be populated")
-	}
-
-	var ownerList2 types.SourcesListResponseV1
-	ts.Request("GET", "/v1/sources", "", ownerKey2).ExpectStatus(200).ExpectBody(&ownerList2)
-	if len(ownerList2.Result) != 0 {
-		t.Fatal("did not expect to see source")
-	}
-
-	ts.Request("PUT", "/v1/sources/testsrc", "{}", ownerKey2).ExpectStatus(403)
-	ts.Request("GET", "/v1/sources/testsrc", "", ownerKey2).ExpectStatus(404)
-	ts.Request("PUT", "/v1/sources/testsrc", "{}", ownerKey).ExpectStatus(200)
 }
 
 func TestServerStackOwners(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
-	db := initTestDB(ctx, t)
-	ts := initTestServer(t, db)
-	defer ts.Close()
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				t.Cleanup(databaseConfig.Cleanup(t, ctr))
+			}
 
-	if err := db.UpsertPrincipal(ctx, database.Principal{Id: "internal", Role: "administrator"}); err != nil {
-		t.Fatal(err)
+			db := (&database.Database{}).WithConfig(databaseConfig.Database(t, ctr).Database)
+			db = initTestDB(t, db)
+			ts := initTestServer(t, db)
+			defer ts.Close()
+
+			if err := db.UpsertPrincipal(ctx, database.Principal{Id: "internal", Role: "administrator"}); err != nil {
+				t.Fatal(err)
+			}
+
+			const ownerKey = "test-stack-owner-key"
+			const ownerKey2 = "test-stack-owner-key2"
+
+			if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "teststackowner", APIKey: ownerKey, Scopes: []config.Scope{{Role: "stack_owner"}}}); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "teststackowner2", APIKey: ownerKey2, Scopes: []config.Scope{{Role: "stack_owner"}}}); err != nil {
+				t.Fatal(err)
+			}
+
+			ts.Request("PUT", "/v1/stacks/teststack", `{}`, ownerKey).ExpectStatus(200)
+
+			var ownerList types.StacksListResponseV1
+			ts.Request("GET", "/v1/stacks", "", ownerKey).ExpectStatus(200).ExpectBody(&ownerList)
+			if len(ownerList.Result) != 1 {
+				t.Fatal("expected exactly one stack")
+			}
+
+			ts.Request("GET", "/v1/stacks/teststack", "", ownerKey).ExpectStatus(200)
+
+			var ownerList2 types.StacksListResponseV1
+			ts.Request("GET", "/v1/stacks", "", ownerKey2).ExpectStatus(200).ExpectBody(&ownerList2)
+			if len(ownerList2.Result) != 0 {
+				t.Fatal("did not expect to see stack")
+			}
+
+			ts.Request("PUT", "/v1/stacks/teststack", `{}`, ownerKey2).ExpectStatus(403)
+			ts.Request("GET", "/v1/stacks/teststack", "", ownerKey2).ExpectStatus(404)
+			ts.Request("PUT", "/v1/stacks/teststack", `{}`, ownerKey).ExpectStatus(200)
+		})
 	}
-
-	const ownerKey = "test-stack-owner-key"
-	const ownerKey2 = "test-stack-owner-key2"
-
-	if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "teststackowner", APIKey: ownerKey, Scopes: []config.Scope{{Role: "stack_owner"}}}); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "teststackowner2", APIKey: ownerKey2, Scopes: []config.Scope{{Role: "stack_owner"}}}); err != nil {
-		t.Fatal(err)
-	}
-
-	ts.Request("PUT", "/v1/stacks/teststack", `{}`, ownerKey).ExpectStatus(200)
-
-	var ownerList types.StacksListResponseV1
-	ts.Request("GET", "/v1/stacks", "", ownerKey).ExpectStatus(200).ExpectBody(&ownerList)
-	if len(ownerList.Result) != 1 {
-		t.Fatal("expected exactly one stack")
-	}
-
-	ts.Request("GET", "/v1/stacks/teststack", "", ownerKey).ExpectStatus(200)
-
-	var ownerList2 types.StacksListResponseV1
-	ts.Request("GET", "/v1/stacks", "", ownerKey2).ExpectStatus(200).ExpectBody(&ownerList2)
-	if len(ownerList2.Result) != 0 {
-		t.Fatal("did not expect to see stack")
-	}
-
-	ts.Request("PUT", "/v1/stacks/teststack", `{}`, ownerKey2).ExpectStatus(403)
-	ts.Request("GET", "/v1/stacks/teststack", "", ownerKey2).ExpectStatus(404)
-	ts.Request("PUT", "/v1/stacks/teststack", `{}`, ownerKey).ExpectStatus(200)
 }
 
 func TestServerSourcePagination(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
-	db := initTestDB(ctx, t)
-	ts := initTestServer(t, db)
-	defer ts.Close()
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				t.Cleanup(databaseConfig.Cleanup(t, ctr))
+			}
 
-	if err := db.UpsertPrincipal(ctx, database.Principal{Id: "internal", Role: "administrator"}); err != nil {
-		t.Fatal(err)
+			db := (&database.Database{}).WithConfig(databaseConfig.Database(t, ctr).Database)
+			db = initTestDB(t, db)
+
+			ts := initTestServer(t, db)
+			defer ts.Close()
+
+			if err := db.UpsertPrincipal(ctx, database.Principal{Id: "internal", Role: "administrator"}); err != nil {
+				t.Fatal(err)
+			}
+
+			const ownerKey = "test-owner-key"
+
+			if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "testowner", APIKey: ownerKey, Scopes: []config.Scope{{Role: "owner"}}}); err != nil {
+				t.Fatal(err)
+			}
+
+			const ownerKey2 = "test-owner-key2"
+
+			if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "testowner2", APIKey: ownerKey2, Scopes: []config.Scope{{Role: "owner"}}}); err != nil {
+				t.Fatal(err)
+			}
+
+			for i := range 200 {
+				ts.Request("PUT", "/v1/sources/testsrc"+strconv.Itoa(i), "{}", ownerKey).ExpectStatus(200)
+			}
+
+			// Create a source for another owner that must not be seen during pagination.
+			ts.Request("PUT", "/v1/sources/othersource", "{}", ownerKey2).ExpectStatus(200)
+
+			var (
+				allSources []*config.Source
+				cursor     string
+				pageCount  int
+			)
+
+			for {
+				url := "/v1/sources?limit=10"
+				if cursor != "" {
+					url += "&cursor=" + cursor
+				}
+				var resp types.SourcesListResponseV1
+				ts.Request("GET", url, "", ownerKey).ExpectStatus(200).ExpectBody(&resp)
+
+				allSources = append(allSources, resp.Result...)
+				if resp.NextCursor == "" {
+					break
+				}
+				cursor = resp.NextCursor
+				pageCount++
+			}
+
+			if len(allSources) != 200 {
+				t.Fatalf("expected 200 sources, got %d", len(allSources))
+			}
+			if pageCount != 20 {
+				t.Fatalf("expected pagination to require multiple pages, got %d", pageCount)
+			}
+		})
 	}
-
-	const ownerKey = "test-owner-key"
-
-	if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "testowner", APIKey: ownerKey, Scopes: []config.Scope{{Role: "owner"}}}); err != nil {
-		t.Fatal(err)
-	}
-
-	const ownerKey2 = "test-owner-key2"
-
-	if err := db.UpsertToken(ctx, "internal", &config.Token{Name: "testowner2", APIKey: ownerKey2, Scopes: []config.Scope{{Role: "owner"}}}); err != nil {
-		t.Fatal(err)
-	}
-
-	for i := range 200 {
-		ts.Request("PUT", "/v1/sources/testsrc"+strconv.Itoa(i), "{}", ownerKey).ExpectStatus(200)
-	}
-
-	// Create a source for another owner that must not be seen during pagination.
-	ts.Request("PUT", "/v1/sources/othersource", "{}", ownerKey2).ExpectStatus(200)
-
-	var (
-		allSources []*config.Source
-		cursor     string
-		pageCount  int
-	)
-
-	for {
-		url := "/v1/sources?limit=10"
-		if cursor != "" {
-			url += "&cursor=" + cursor
-		}
-		var resp types.SourcesListResponseV1
-		ts.Request("GET", url, "", ownerKey).ExpectStatus(200).ExpectBody(&resp)
-
-		allSources = append(allSources, resp.Result...)
-		if resp.NextCursor == "" {
-			break
-		}
-		cursor = resp.NextCursor
-		pageCount++
-	}
-
-	if len(allSources) != 200 {
-		t.Fatalf("expected 200 sources, got %d", len(allSources))
-	}
-	if pageCount != 20 {
-		t.Fatalf("expected pagination to require multiple pages, got %d", pageCount)
-	}
-
 }
 
 func TestServerHealthEndpoint(t *testing.T) {
@@ -351,8 +414,8 @@ func TestServerHealthEndpoint(t *testing.T) {
 	ts := initTestServer(t, nil)
 	defer ts.Close()
 
-	notReady := func(_ context.Context) error { return errors.New("not ready") }
-	ready := func(_ context.Context) error { return nil }
+	notReady := func(context.Context) error { return errors.New("not ready") }
+	ready := func(context.Context) error { return nil }
 
 	ts.srv.readyFn = notReady
 
@@ -366,13 +429,15 @@ func TestServerHealthEndpoint(t *testing.T) {
 
 }
 
-func initTestDB(ctx context.Context, t *testing.T) *database.Database {
+func initTestDB(t *testing.T, db *database.Database) *database.Database {
 	t.Helper()
-	var db database.Database
-	if err := db.InitDB(ctx); err != nil {
+	if db == nil {
+		db = &database.Database{}
+	}
+	if err := db.InitDB(t.Context()); err != nil {
 		t.Fatal(err)
 	}
-	return &db
+	return db
 }
 
 type testServer struct {

--- a/internal/test/dbs/dbs.go
+++ b/internal/test/dbs/dbs.go
@@ -1,0 +1,119 @@
+package dbs
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/styrainc/opa-control-plane/internal/config"
+	"github.com/styrainc/opa-control-plane/internal/database"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/mysql"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+type Setup struct {
+	Setup    func(*testing.T) testcontainers.Container
+	Database func(*testing.T, testcontainers.Container) *config.Root
+	Cleanup  func(*testing.T, testcontainers.Container) func()
+}
+
+func tcCleanup(t *testing.T, ctr testcontainers.Container) func() {
+	return func() {
+		if err := testcontainers.TerminateContainer(ctr); err != nil {
+			t.Fatalf("failed to terminate container: %s", err)
+		}
+	}
+}
+
+func Configs(t *testing.T) map[string]Setup {
+	t.Helper()
+	return map[string]Setup{
+		"sqlite-memory-only": {
+			Database: func(t *testing.T, ctr testcontainers.Container) *config.Root {
+				return &config.Root{
+					Database: &config.Database{
+						SQL: &config.SQLDatabase{
+							Driver: "sqlite3",
+							DSN:    database.SQLiteMemoryOnlyDSN,
+						},
+					},
+				}
+			},
+		},
+		"sqlite-persistence": {
+			Database: func(t *testing.T, ctr testcontainers.Container) *config.Root {
+				return &config.Root{
+					Database: &config.Database{
+						SQL: &config.SQLDatabase{
+							Driver: "sqlite3",
+							DSN:    filepath.Join(t.TempDir(), "test.db"),
+						},
+					},
+				}
+			},
+		},
+		"postgres": {
+			Setup: func(t *testing.T) testcontainers.Container {
+				ctr, err := postgres.Run(
+					t.Context(),
+					"postgres:16-alpine",
+					postgres.WithDatabase("db"),
+					postgres.WithUsername("user"),
+					postgres.WithPassword("password"),
+					postgres.BasicWaitStrategies(),
+					postgres.WithSQLDriver("pgx"),
+				)
+				if err != nil {
+					t.Fatal("failed to start postgres container:", err)
+				}
+				return ctr
+			},
+			Cleanup: tcCleanup,
+			Database: func(t *testing.T, ctr testcontainers.Container) *config.Root {
+				dsn, err := ctr.(*postgres.PostgresContainer).ConnectionString(t.Context())
+				if err != nil {
+					t.Fatalf("failed to get postgres connection string: %v", err)
+				}
+
+				return &config.Root{
+					Database: &config.Database{
+						SQL: &config.SQLDatabase{
+							Driver: "postgres",
+							DSN:    dsn,
+						},
+					},
+				}
+			},
+		},
+		"mysql": {
+			Setup: func(t *testing.T) testcontainers.Container {
+				ctr, err := mysql.Run(t.Context(),
+					"mysql:8.0",
+					mysql.WithDatabase("db"),
+					mysql.WithUsername("user"),
+					mysql.WithPassword("password"),
+				)
+				if err != nil {
+					t.Fatal("failed to start mysql container:", err)
+				}
+				return ctr
+			},
+			Cleanup: tcCleanup,
+			Database: func(t *testing.T, ctr testcontainers.Container) *config.Root {
+				dsn, err := ctr.(*mysql.MySQLContainer).ConnectionString(t.Context())
+				if err != nil {
+					t.Fatalf("failed to get mysql connection string: %v", err)
+				}
+
+				return &config.Root{
+					Database: &config.Database{
+						SQL: &config.SQLDatabase{
+							Driver: "mysql",
+							DSN:    dsn,
+						},
+					},
+				}
+			},
+		},
+	}
+}


### PR DESCRIPTION
This makes our test suite a bit slower, but it would have caught the parameter error that was fixed in #65.

Let's roll with it for a bit, we can exclude mysql (the slowest database container) if we find it too annoying.