### PR TITLE
Dropping `go-test` timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ go-build: generate
 
 .PHONY: go-test
 go-test: generate
-	$(GO) test -timeout=90s $(GO_TAGS) ./...
+	$(GO) test $(GO_TAGS) ./...
 
 .PHONY: go-bench
 go-bench: generate


### PR DESCRIPTION
To not panic on slower systems, and to give us some time before GH turns flaky ;).