### PR TITLE
ci: Add Makefile targets and update GHA workflow to publish images

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   tests:
+    name: Run Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -27,3 +28,24 @@ jobs:
 
       - name: Run Makefile target `library-test`
         run: make library-test
+
+  deploy-edge:
+    name: Push Edge Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build and Push
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        # Only run if required secrets are provided
+        if: ${{ env.DOCKER_USER && env.DOCKER_PASSWORD }}
+        run: make deploy-ci

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bundles/
 data
 opactl_*
 files
+.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+ARG BASE
+
+FROM ${BASE}
+
+# Any non-zero number will do, and unfortunately a named user will not, as k8s
+# pod securityContext runAsNonRoot can't resolve the user ID:
+# https://github.com/kubernetes/kubernetes/issues/40958.
+ARG USER=1000:1000
+USER ${USER}
+
+# TARGETOS and TARGETARCH are automatic platform args injected by BuildKit
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY opactl_${TARGETOS}_${TARGETARCH} /ocp
+
+ENTRYPOINT ["/ocp"]
+
+CMD ["run"]

--- a/build/get-build-version.sh
+++ b/build/get-build-version.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+awk -F'"' '/^var Version/{print $2}' version/version.go

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,4 @@
+// Package version contains version information that is set at build time.
+package version
+
+var Version = "0.1.0-dev"


### PR DESCRIPTION
This change adds the Makefile targets that create OCP Docker images and pushes them to Docker Hub. It also updates the GHA workflow such that the edge variant of the image containing the latest changes is pushed to Docker Hub on pushes to main.

Fixes: #3