### PR TITLE
Use app version from the cmd package

### DIFF
--- a/build/get-build-version.sh
+++ b/build/get-build-version.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-awk -F'"' '/^var Version/{print $2}' version/version.go
+awk -F'"' '/^var Version/{print $2}' cmd/version/version.go

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -11,9 +11,7 @@ import (
 	"github.com/styrainc/opa-control-plane/cmd"
 )
 
-var (
-	version = "0.0.0-dev"
-)
+var Version = "0.1.0-dev"
 
 func init() {
 	version := &cobra.Command{
@@ -58,7 +56,7 @@ func generateCmdOutput(out io.Writer) {
 		binVcs += "-dirty"
 	}
 
-	fmt.Fprintln(out, "Version: "+version)
+	fmt.Fprintln(out, "Version: "+Version)
 	fmt.Fprintln(out, "Build Commit: "+binVcs)
 	fmt.Fprintln(out, "Build Timestamp: "+binTimestamp)
 	fmt.Fprintln(out, "Build Hostname: "+hostname)

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,0 @@
-// Package version contains version information that is set at build time.
-package version
-
-var Version = "0.1.0-dev"


### PR DESCRIPTION
Use the existing version info in the cmd package instead of duplicating info in a new package.