### PR TITLE
config|database: make 'datasources->credentials' work

### DIFF
--- a/e2e/cli/build_http_transform.txtar
+++ b/e2e/cli/build_http_transform.txtar
@@ -1,0 +1,45 @@
+exec $OPACTL build --config config.d/bundle.yml --data-dir tmp --non-interactive --log-level debug
+stderr '^1/1 bundles built and pushed successfully$'
+! stdout .
+
+exec tar tf bundles/hello-world/bundle.tar.gz
+cmp stdout exp/tarball
+
+exec tar xf bundles/hello-world/bundle.tar.gz /data.json
+cmp data.json exp/data.json
+
+-- config.d/bundle.yml --
+bundles:
+  hello-world:
+    object_storage:
+      filesystem:
+        path: bundles/hello-world/bundle.tar.gz
+    requirements:
+    - source: http-with-transform
+    excluded_files:
+    - transform.rego
+sources:
+  http-with-transform:
+    datasources:
+    - type: http
+      name: hello
+      path: github
+      transform_query: data.transform.rule
+      config:
+        url: https://api.github.com/repos/open-policy-agent/opa/releases/tags/v1.8.0
+      credentials: github-token # NOTE(sr): There's no easy way to tell that this had an effect
+    directory: aux/
+    paths:
+    - transform.rego
+secrets:
+  github-token:
+    type: token_auth
+    token: ${E2E_GITHUB_TOKEN}
+-- aux/transform.rego --
+package transform
+rule.created := input.created_at
+-- exp/tarball --
+/data.json
+/.manifest
+-- exp/data.json --
+{"github":{"created":"2025-08-28T14:49:47Z"}}

--- a/e2e/cli/main_test.go
+++ b/e2e/cli/main_test.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"cmp"
 	"fmt"
 	"os"
 	"strings"
@@ -15,10 +16,11 @@ import (
 )
 
 func TestScript(t *testing.T) {
+	opactl := cmp.Or(os.Getenv("OPACTL"), "opactl")
 	testscript.Run(t, testscript.Params{
 		Dir: ".",
 		Setup: func(e *testscript.Env) error {
-			e.Vars = append(e.Vars, "OPACTL="+os.Getenv("OPACTL"))
+			e.Vars = append(e.Vars, "OPACTL="+opactl)
 			for _, kv := range os.Environ() {
 				if strings.HasPrefix(kv, "E2E_") {
 					e.Vars = append(e.Vars, kv)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -826,9 +826,13 @@ WHERE (sources_secrets.ref_type = 'git_credentials' OR sources_secrets.ref_type 
 		sources_datasources.path,
 		sources_datasources.type,
 		sources_datasources.config,
-		sources_datasources.transform_query
+		sources_datasources.transform_query,
+	    sources_datasources.secret_name,
+	    secrets.value AS secret_value
 	FROM
 		sources_datasources
+	LEFT JOIN
+		secrets ON sources_datasources.secret_name = secrets.name
 	`)
 		if err != nil {
 			return nil, "", err
@@ -838,7 +842,8 @@ WHERE (sources_secrets.ref_type = 'git_credentials' OR sources_secrets.ref_type 
 
 		for rows2.Next() {
 			var name, source_name, path, type_, configuration, transformQuery string
-			if err := rows2.Scan(&name, &source_name, &path, &type_, &configuration, &transformQuery); err != nil {
+			var secretName, secretValue string
+			if err := rows2.Scan(&name, &source_name, &path, &type_, &configuration, &transformQuery, &secretName, &secretValue); err != nil {
 				return nil, "", err
 			}
 
@@ -851,6 +856,16 @@ WHERE (sources_secrets.ref_type = 'git_credentials' OR sources_secrets.ref_type 
 
 			if err := json.Unmarshal([]byte(configuration), &datasource.Config); err != nil {
 				return nil, "", err
+			}
+
+			if secretName != "" {
+				s := config.Secret{Name: secretName}
+				if secretValue != "" {
+					if err := json.Unmarshal([]byte(secretValue), &s.Value); err != nil {
+						return nil, "", err
+					}
+				}
+				datasource.Credentials = s.Ref()
 			}
 
 			src, ok := srcMap[source_name]
@@ -1172,10 +1187,19 @@ func (d *Database) UpsertSource(ctx context.Context, principal string, source *c
 				return err
 			}
 
-			if err := d.upsert(ctx, tx, "sources_datasources", []string{"source_name", "name", "type", "path", "config", "transform_query"},
-				[]string{"source_name", "name"},
-				source.Name, datasource.Name, datasource.Type, datasource.Path, string(bs), datasource.TransformQuery); err != nil {
-				return err
+			if datasource.Credentials != nil {
+				secret := datasource.Credentials.Name
+				if err := d.upsert(ctx, tx, "sources_datasources", []string{"source_name", "name", "type", "path", "config", "transform_query", "secret_name"},
+					[]string{"source_name", "name"},
+					source.Name, datasource.Name, datasource.Type, datasource.Path, string(bs), datasource.TransformQuery, secret); err != nil {
+					return err
+				}
+			} else { // sans secret (TODO(sr): Any more ergonomic way?)
+				if err := d.upsert(ctx, tx, "sources_datasources", []string{"source_name", "name", "type", "path", "config", "transform_query"},
+					[]string{"source_name", "name"},
+					source.Name, datasource.Name, datasource.Type, datasource.Path, string(bs), datasource.TransformQuery); err != nil {
+					return err
+				}
 			}
 		}
 

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -78,13 +78,6 @@ var schema = []sqlTable{
 		PrimaryKey("source_name", "secret_name").
 		ForeignKey("source_name", "sources(name)").
 		ForeignKey("secret_name", "secrets(name)"),
-	createSQLTable("sources_secrets").
-		VarCharNonNullColumn("source_name").
-		VarCharNonNullColumn("secret_name").
-		TextNonNullColumn("ref_type").
-		PrimaryKey("source_name", "secret_name").
-		ForeignKey("source_name", "sources(name)").
-		ForeignKey("secret_name", "secrets(name)"),
 	createSQLTable("sources_data").
 		VarCharNonNullColumn("source_name").
 		VarCharNonNullColumn("path").
@@ -94,11 +87,13 @@ var schema = []sqlTable{
 	createSQLTable("sources_datasources").
 		VarCharNonNullColumn("name").
 		VarCharNonNullColumn("source_name").
+		TextColumn("secret_name").
 		TextNonNullColumn("type").
 		TextNonNullColumn("path").
 		TextNonNullColumn("config").
 		TextNonNullColumn("transform_query").
 		PrimaryKey("source_name", "name").
+		ForeignKey("secret_name", "secrets(name)").
 		ForeignKey("source_name", "sources(name)"),
 	createSQLTable("principals").
 		VarCharPrimaryKeyColumn("id").

--- a/internal/httpsync/httpsync.go
+++ b/internal/httpsync/httpsync.go
@@ -56,7 +56,7 @@ func (s *HttpDataSynchronizer) Execute(ctx context.Context) error {
 	return err
 }
 
-func (*HttpDataSynchronizer) Close(_ context.Context) {
+func (*HttpDataSynchronizer) Close(context.Context) {
 	// No resources to close for HTTP synchronizer
 }
 
@@ -81,7 +81,8 @@ func (s *HttpDataSynchronizer) setHeaders(ctx context.Context, req *http.Request
 		req.SetBasicAuth(value.Username, value.Password)
 	case config.SecretTokenAuth:
 		req.Header.Set("Authorization", "Bearer "+value.Token)
+	default:
+		return fmt.Errorf("unsupported authentication type: %T", value)
 	}
-
-	return fmt.Errorf("unsupported authentication type: %T", value)
+	return nil
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -298,9 +298,9 @@ func (s *Service) launchWorkers(ctx context.Context) {
 			sort.Strings(sorted)
 			var extra string
 			if len(sorted) > 1 {
-				extra = " (along with %d other sources)"
+				extra = fmt.Sprintf(" (along with %d other sources)", len(sorted)-1)
 			}
-			failures[b.Name] = Status{State: BuildStateConfigError, Message: fmt.Sprintf("requirements on %q conflict%v", sorted[0], extra)}
+			failures[b.Name] = Status{State: BuildStateConfigError, Message: fmt.Sprintf("requirements on %q conflict%s", sorted[0], extra)}
 			continue
 		}
 


### PR DESCRIPTION
Before, this wasn't persisted to the database, and not read back. So referencing a token among the secrets (type "token_auth") had no effect.

-----

So I have manually verified that the API works with this, too -- but I have yet to add some more tests for that.

Also, the added txtar case works -- but it also worked when the credentials didn't work: the GH API just uses different rate limiting when the header is present.