### PR TITLE
misc data-source related fixes and tests

### DIFF
--- a/e2e/cli/build_git_local.txtar
+++ b/e2e/cli/build_git_local.txtar
@@ -1,0 +1,54 @@
+# local example git repo
+cd repo
+env HOME=.
+exec git init .
+exec git branch -m main
+exec git config --global user.name "botbotbot" 
+exec git config --global user.email "bot@bot.bot" 
+exec git add users.json
+exec git commit -m initial-commit
+cd ..
+
+exec $OPACTL build --config config.d/bundle.yml --data-dir tmp
+stderr '^1/1 bundles built and pushed successfully$'
+! stdout .
+
+exec tar tf bundles/a.tar.gz
+cmp stdout exp/tarball
+
+exec tar xf bundles/a.tar.gz
+cmp data.json exp/data.json
+cmp .manifest exp/.manifest
+
+
+-- repo/users.json --
+{
+  "users": [
+    {
+      "id": "alice"
+    },
+    {
+      "id": "bob"
+    }
+  ]
+}
+-- config.d/bundle.yml --
+bundles:
+  hello-world:
+    object_storage:
+      filesystem:
+        path: bundles/a.tar.gz
+    requirements:
+    - source: git-data
+sources:
+  git-data:
+    git:
+      repo: ./repo/
+      reference: main
+-- exp/tarball --
+/data.json
+/.manifest
+-- exp/data.json --
+{"users":[{"id":"alice"},{"id":"bob"}]}
+-- exp/.manifest --
+{"revision":"","roots":[""],"rego_version":0}

--- a/e2e/cli/build_git_ssh_auth.txtar
+++ b/e2e/cli/build_git_ssh_auth.txtar
@@ -9,9 +9,7 @@ cmp stdout exp/tarball
 
 exec tar xf bundles/hello-world/bundle.tar.gz
 cmp data.json exp/data.json
-
-# TODO(sr): the manifest detection seems to be broken on windows, it yields roots: null
-[!windows] cmp .manifest exp/.manifest
+cmp .manifest exp/.manifest
 
 exec sha512sum --check checksum_rego
 

--- a/e2e/cli/build_git_ssh_auth.txtar
+++ b/e2e/cli/build_git_ssh_auth.txtar
@@ -10,6 +10,9 @@ cmp stdout exp/tarball
 exec tar xf bundles/hello-world/bundle.tar.gz
 cmp data.json exp/data.json
 
+# TODO(sr): the manifest detection seems to be broken on windows, it yields roots: null
+[!windows] cmp .manifest exp/.manifest
+
 exec sha512sum --check checksum_rego
 
 -- config.d/bundle.yml --
@@ -27,8 +30,6 @@ sources:
       commit: 0f81d9a0018451d98dcd3f4bb885ee676f49f6fe
       included_files:
       - k8s_authorization/policy/policy.rego
-      excluded_files:
-      - .*/*
       credentials: policies-github-token
 secrets:
   policies-github-token:
@@ -41,5 +42,7 @@ secrets:
 /.manifest
 -- exp/data.json --
 {}
+-- exp/.manifest --
+{"revision":"","roots":["k8s/authz"],"rego_version":0}
 -- checksum_rego --
 255e743f5253095547c30e48195819c9a0faac6296337d5b24defb3fb4efc67ca048d85f9bdc30cd521b04b1bbc67164a5b7066563c0fc772d7bfb45a6a4c822 k8s_authorization/policy/policy.rego

--- a/e2e/cli/build_http_transform.txtar
+++ b/e2e/cli/build_http_transform.txtar
@@ -5,8 +5,9 @@ stderr '^1/1 bundles built and pushed successfully$'
 exec tar tf bundles/hello-world/bundle.tar.gz
 cmp stdout exp/tarball
 
-exec tar xf bundles/hello-world/bundle.tar.gz /data.json
+exec tar xf bundles/hello-world/bundle.tar.gz
 cmp data.json exp/data.json
+cmp .manifest exp/.manifest
 
 -- config.d/bundle.yml --
 bundles:
@@ -62,3 +63,5 @@ rule := [u, p] if {
 /.manifest
 -- exp/data.json --
 {"basicauth":["user001","letmein"],"headers":["open","sesame"]}
+-- exp/.manifest --
+{"revision":"","roots":["basicauth","headers"],"rego_version":0}

--- a/e2e/cli/build_http_transform_inline.txtar
+++ b/e2e/cli/build_http_transform_inline.txtar
@@ -1,0 +1,37 @@
+exec $OPACTL build --config config.d/bundle.yml --data-dir tmp
+stderr '^1/1 bundles built and pushed successfully$'
+! stdout .
+
+exec tar tf bundles/hello-world/bundle.tar.gz
+cmp stdout exp/tarball
+
+exec tar xf bundles/hello-world/bundle.tar.gz
+cmp data.json exp/data.json
+cmp .manifest exp/.manifest
+
+-- config.d/bundle.yml --
+bundles:
+  hello-world:
+    object_storage:
+      filesystem:
+        path: bundles/hello-world/bundle.tar.gz
+    requirements:
+    - source: http-with-transform
+    excluded_files:
+    - transform.rego
+sources:
+  http-with-transform:
+    datasources:
+    - type: http
+      name: hello
+      path: users
+      transform_query: '{user.id: object.remove(user, {"id"}) | user := input.users[_]}'
+      config:
+        url: http://127.0.0.1:9991/users
+-- exp/tarball --
+/data.json
+/.manifest
+-- exp/data.json --
+{"users":{"alice":{"roles":["admin","editor"]},"bob":{"roles":["viewer"]}}}
+-- exp/.manifest --
+{"revision":"","roots":["users"],"rego_version":0}

--- a/e2e/cli/main_test.go
+++ b/e2e/cli/main_test.go
@@ -25,6 +25,23 @@ func testServer() {
 			fmt.Fprintln(w, err.Error())
 		}
 	})
+	mux.HandleFunc("GET /users", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("content-type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"users": []map[string]any{
+				{
+					"id":    "alice",
+					"roles": []string{"admin", "editor"},
+				},
+				{
+					"id":    "bob",
+					"roles": []string{"viewer"},
+				},
+			},
+		}); err != nil {
+			fmt.Fprintln(w, err.Error())
+		}
+	})
 
 	http.ListenAndServe(":9991", mux)
 }

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -270,14 +270,15 @@ func walkFilesRecursive(excludes []glob.Glob, dir Dir, suffixes []string, fn fun
 		if fi.IsDir() {
 			return nil
 		}
-		if isExcluded(strings.TrimPrefix(path, dir.Path+"/"), excludes) {
+		// NB(sr): All our globs are "/"-separated, so we need to check for inclusion/exclusion on
+		// the ToSlash-ed path.
+		trimmed := strings.TrimPrefix(filepath.ToSlash(path), dir.Path+"/")
+		if isExcluded(trimmed, excludes) || !isIncluded(trimmed, includes) {
 			return nil
 		}
-		if !isIncluded(strings.TrimPrefix(path, dir.Path+"/"), includes) {
-			return nil
-		}
+		ext := filepath.Ext(path)
 		if !slices.ContainsFunc(suffixes, func(s string) bool {
-			return strings.EqualFold(s, filepath.Ext(path))
+			return strings.EqualFold(s, ext)
 		}) {
 			return nil
 		}

--- a/internal/gitsync/gitsync.go
+++ b/internal/gitsync/gitsync.go
@@ -28,7 +28,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const configFile = "ocp.yaml"
+// configFile is an internal config file used to track if a git repository
+// can be re-used or needs to be wiped.
+// NB(sr): If this is called '*.yaml', or '*.json', it'll be picked up by the
+// bundle builder.
+const configFile = "ocpconfig"
 
 func init() {
 	// For Azure DevOps compatibility. More details: https://github.com/go-git/go-git/issues/64


### PR DESCRIPTION
See the individual commits, please.

1. adds an inline transform to assert that what's documented works (cf. https://github.com/open-policy-agent/opa/pull/7913)
2. cleans up the ssh_auth git checkout test
3. fixes #88, adding an e2e test for it.

For (3.) there are certainly nicer fixes, but this won't block us from implementing these later on, and fixes the issue at hand now.