### PR TITLE
refactor: Swap out gorilla/mux -> net/http ServeMux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -218,7 +218,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-cmp v0.7.0
-	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/johannesboyne/gofakes3 v0.0.0-20250402064820-d479899d8cbe

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,6 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.6 h1:GW/XbdyBFQ8Qe+YAmFU
 github.com/googleapis/enterprise-certificate-proxy v0.3.6/go.mod h1:MkHOF77EYAE7qfSuSS9PU6g4Nt4e11cnsDUowfwewLA=
 github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81vgd/bo=
 github.com/googleapis/gax-go/v2 v2.15.0/go.mod h1:zVVkkxAQHa1RQpg9z2AUCMnKhi0Qld9rcmyfL1OZhoc=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 h1:X5VWvz21y3gzm9Nw/kaUeku/1+uBhcekkmy4IkffJww=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1/go.mod h1:Zanoh4+gvIgluNqcfMVTJueD4wSS5hT7zTt4Mrutd90=
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -48,24 +48,6 @@ func (s *Server) Init() *Server {
 	s.router.HandleFunc("PUT    /v1/stacks/{stack}", authenticationMiddleware(s.db, s.v1StacksPut))
 	s.router.HandleFunc("GET    /v1/stacks/{stack}", authenticationMiddleware(s.db, s.v1StacksGet))
 
-	// public := s.router.PathPrefix("/").Subrouter()
-	// public.Handle("/health", http.HandlerFunc(s.health)).Methods(http.MethodGet)
-
-	// api := s.router.PathPrefix("/v1").Subrouter()
-	// api.Handle("/sources/{source:.+}/data/{path:.+}", http.HandlerFunc(s.v1SourcesDataGet)).Methods(http.MethodGet)
-	// api.Handle("/sources/{source:.+}/data/{path:.+}", http.HandlerFunc(s.v1SourcesDataPut)).Methods(http.MethodPost, http.MethodPut)
-	// api.Handle("/sources/{source:.+}/data/{path:.+}", http.HandlerFunc(s.v1SourcesDataDelete)).Methods(http.MethodDelete)
-	// api.Handle("/sources", http.HandlerFunc(s.v1SourcesList)).Methods(http.MethodGet)
-	// api.Handle("/sources/{source:.+}", http.HandlerFunc(s.v1SourcesPut)).Methods(http.MethodPut)
-	// api.Handle("/sources/{source:.+}", http.HandlerFunc(s.v1SourcesGet)).Methods(http.MethodGet)
-	// api.Handle("/bundles", http.HandlerFunc(s.v1BundlesList)).Methods(http.MethodGet)
-	// api.Handle("/bundles/{bundle:.+}", http.HandlerFunc(s.v1BundlesPut)).Methods(http.MethodPut)
-	// api.Handle("/bundles/{bundle:.+}", http.HandlerFunc(s.v1BundlesGet)).Methods(http.MethodGet)
-	// api.Handle("/stacks", http.HandlerFunc(s.v1StacksList)).Methods(http.MethodGet)
-	// api.Handle("/stacks/{stack:.+}", http.HandlerFunc(s.v1StacksPut)).Methods(http.MethodPut)
-	// api.Handle("/stacks/{stack:.+}", http.HandlerFunc(s.v1StacksGet)).Methods(http.MethodGet)
-	// api.Use(authenticationMiddleware(s.db))
-
 	return s
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gorilla/mux"
 	"github.com/open-policy-agent/opa/v1/server/writer"
 	"github.com/styrainc/opa-control-plane/internal/config"
 	"github.com/styrainc/opa-control-plane/internal/database"
@@ -19,7 +18,7 @@ import (
 )
 
 type Server struct {
-	router  *mux.Router
+	router  *http.ServeMux
 	db      *database.Database
 	readyFn func(context.Context) error
 }
@@ -30,31 +29,47 @@ func New() *Server {
 
 func (s *Server) Init() *Server {
 	if s.router == nil {
-		s.router = mux.NewRouter()
+		s.router = http.NewServeMux()
 	}
 
-	public := s.router.PathPrefix("/").Subrouter()
-	public.Handle("/health", http.HandlerFunc(s.health)).Methods(http.MethodGet)
+	s.router.HandleFunc("GET    /health", s.health)
 
-	api := s.router.PathPrefix("/v1").Subrouter()
-	api.Handle("/sources/{source:.+}/data/{path:.+}", http.HandlerFunc(s.v1SourcesDataGet)).Methods(http.MethodGet)
-	api.Handle("/sources/{source:.+}/data/{path:.+}", http.HandlerFunc(s.v1SourcesDataPut)).Methods(http.MethodPost, http.MethodPut)
-	api.Handle("/sources/{source:.+}/data/{path:.+}", http.HandlerFunc(s.v1SourcesDataDelete)).Methods(http.MethodDelete)
-	api.Handle("/sources", http.HandlerFunc(s.v1SourcesList)).Methods(http.MethodGet)
-	api.Handle("/sources/{source:.+}", http.HandlerFunc(s.v1SourcesPut)).Methods(http.MethodPut)
-	api.Handle("/sources/{source:.+}", http.HandlerFunc(s.v1SourcesGet)).Methods(http.MethodGet)
-	api.Handle("/bundles", http.HandlerFunc(s.v1BundlesList)).Methods(http.MethodGet)
-	api.Handle("/bundles/{bundle:.+}", http.HandlerFunc(s.v1BundlesPut)).Methods(http.MethodPut)
-	api.Handle("/bundles/{bundle:.+}", http.HandlerFunc(s.v1BundlesGet)).Methods(http.MethodGet)
-	api.Handle("/stacks", http.HandlerFunc(s.v1StacksList)).Methods(http.MethodGet)
-	api.Handle("/stacks/{stack:.+}", http.HandlerFunc(s.v1StacksPut)).Methods(http.MethodPut)
-	api.Handle("/stacks/{stack:.+}", http.HandlerFunc(s.v1StacksGet)).Methods(http.MethodGet)
-	api.Use(authenticationMiddleware(s.db))
+	s.router.HandleFunc("GET    /v1/sources/{source}/data/{path...}", authenticationMiddleware(s.db, s.v1SourcesDataGet))
+	s.router.HandleFunc("POST   /v1/sources/{source}/data/{path...}", authenticationMiddleware(s.db, s.v1SourcesDataPut))
+	s.router.HandleFunc("PUT    /v1/sources/{source}/data/{path...}", authenticationMiddleware(s.db, s.v1SourcesDataPut))
+	s.router.HandleFunc("DELETE /v1/sources/{source}/data/{path...}", authenticationMiddleware(s.db, s.v1SourcesDataDelete))
+	s.router.HandleFunc("GET    /v1/sources", authenticationMiddleware(s.db, s.v1SourcesList))
+	s.router.HandleFunc("PUT    /v1/sources/{source}", authenticationMiddleware(s.db, s.v1SourcesPut))
+	s.router.HandleFunc("GET    /v1/sources/{source}", authenticationMiddleware(s.db, s.v1SourcesGet))
+	s.router.HandleFunc("GET    /v1/bundles", authenticationMiddleware(s.db, s.v1BundlesList))
+	s.router.HandleFunc("PUT    /v1/bundles/{bundle}", authenticationMiddleware(s.db, s.v1BundlesPut))
+	s.router.HandleFunc("GET    /v1/bundles/{bundle}", authenticationMiddleware(s.db, s.v1BundlesGet))
+	s.router.HandleFunc("GET    /v1/stacks", authenticationMiddleware(s.db, s.v1StacksList))
+	s.router.HandleFunc("PUT    /v1/stacks/{stack}", authenticationMiddleware(s.db, s.v1StacksPut))
+	s.router.HandleFunc("GET    /v1/stacks/{stack}", authenticationMiddleware(s.db, s.v1StacksGet))
+
+	// public := s.router.PathPrefix("/").Subrouter()
+	// public.Handle("/health", http.HandlerFunc(s.health)).Methods(http.MethodGet)
+
+	// api := s.router.PathPrefix("/v1").Subrouter()
+	// api.Handle("/sources/{source:.+}/data/{path:.+}", http.HandlerFunc(s.v1SourcesDataGet)).Methods(http.MethodGet)
+	// api.Handle("/sources/{source:.+}/data/{path:.+}", http.HandlerFunc(s.v1SourcesDataPut)).Methods(http.MethodPost, http.MethodPut)
+	// api.Handle("/sources/{source:.+}/data/{path:.+}", http.HandlerFunc(s.v1SourcesDataDelete)).Methods(http.MethodDelete)
+	// api.Handle("/sources", http.HandlerFunc(s.v1SourcesList)).Methods(http.MethodGet)
+	// api.Handle("/sources/{source:.+}", http.HandlerFunc(s.v1SourcesPut)).Methods(http.MethodPut)
+	// api.Handle("/sources/{source:.+}", http.HandlerFunc(s.v1SourcesGet)).Methods(http.MethodGet)
+	// api.Handle("/bundles", http.HandlerFunc(s.v1BundlesList)).Methods(http.MethodGet)
+	// api.Handle("/bundles/{bundle:.+}", http.HandlerFunc(s.v1BundlesPut)).Methods(http.MethodPut)
+	// api.Handle("/bundles/{bundle:.+}", http.HandlerFunc(s.v1BundlesGet)).Methods(http.MethodGet)
+	// api.Handle("/stacks", http.HandlerFunc(s.v1StacksList)).Methods(http.MethodGet)
+	// api.Handle("/stacks/{stack:.+}", http.HandlerFunc(s.v1StacksPut)).Methods(http.MethodPut)
+	// api.Handle("/stacks/{stack:.+}", http.HandlerFunc(s.v1StacksGet)).Methods(http.MethodGet)
+	// api.Use(authenticationMiddleware(s.db))
 
 	return s
 }
 
-func (s *Server) WithRouter(router *mux.Router) *Server {
+func (s *Server) WithRouter(router *http.ServeMux) *Server {
 	s.router = router
 	return s
 }
@@ -102,9 +117,8 @@ func (s *Server) v1BundlesList(w http.ResponseWriter, r *http.Request) {
 func (s *Server) v1BundlesPut(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
-	vars := mux.Vars(r)
 
-	name, err := url.PathUnescape(vars["bundle"])
+	name, err := url.PathUnescape(r.PathValue("bundle"))
 	if err != nil {
 		ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
 		return
@@ -134,9 +148,8 @@ func (s *Server) v1BundlesPut(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) v1BundlesGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	vars := mux.Vars(r)
 
-	name, err := url.PathUnescape(vars["bundle"])
+	name, err := url.PathUnescape(r.PathValue("bundle"))
 	if err != nil {
 		ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
 		return
@@ -153,7 +166,6 @@ func (s *Server) v1BundlesGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) v1SourcesList(w http.ResponseWriter, r *http.Request) {
-
 	ctx := r.Context()
 	opts := s.listOptions(r)
 	sources, nextCursor, err := s.db.ListSources(ctx, s.auth(r), opts)
@@ -167,11 +179,9 @@ func (s *Server) v1SourcesList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) v1SourcesPut(w http.ResponseWriter, r *http.Request) {
-
 	ctx := r.Context()
-	vars := mux.Vars(r)
 
-	name, err := url.PathUnescape(vars["source"])
+	name, err := url.PathUnescape(r.PathValue("source"))
 	if err != nil {
 		ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
 		return
@@ -201,9 +211,8 @@ func (s *Server) v1SourcesPut(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) v1SourcesGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	vars := mux.Vars(r)
 
-	name, err := url.PathUnescape(vars["source"])
+	name, err := url.PathUnescape(r.PathValue("source"))
 	if err != nil {
 		ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
 		return
@@ -222,15 +231,14 @@ func (s *Server) v1SourcesGet(w http.ResponseWriter, r *http.Request) {
 // v1SourcesDataGet handles GET requests to retrieve data from a source.
 func (s *Server) v1SourcesDataGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	vars := mux.Vars(r)
 
-	name, err := url.PathUnescape(vars["source"])
+	name, err := url.PathUnescape(r.PathValue("source"))
 	if err != nil {
 		ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
 		return
 	}
 
-	data, ok, err := s.db.SourcesDataGet(ctx, name, path.Join(vars["path"], "data.json"), s.auth(r))
+	data, ok, err := s.db.SourcesDataGet(ctx, name, path.Join(r.PathValue("path"), "data.json"), s.auth(r))
 	if err != nil {
 		errorAuto(w, err)
 		return
@@ -248,9 +256,8 @@ func (s *Server) v1SourcesDataGet(w http.ResponseWriter, r *http.Request) {
 // v1SourcesDataPut handles PUT and POST requests to upload data to a source.
 func (s *Server) v1SourcesDataPut(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	vars := mux.Vars(r)
 
-	name, err := url.PathUnescape(vars["source"])
+	name, err := url.PathUnescape(r.PathValue("source"))
 	if err != nil {
 		ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
 		return
@@ -262,7 +269,7 @@ func (s *Server) v1SourcesDataPut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = s.db.SourcesDataPut(ctx, name, path.Join(vars["path"], "data.json"), value, s.auth(r))
+	err = s.db.SourcesDataPut(ctx, name, path.Join(r.PathValue("path"), "data.json"), value, s.auth(r))
 	if err != nil {
 		errorAuto(w, err)
 		return
@@ -275,15 +282,14 @@ func (s *Server) v1SourcesDataPut(w http.ResponseWriter, r *http.Request) {
 // v1SourcesDataDelete handles DELETE requests to remove data from a source.
 func (s *Server) v1SourcesDataDelete(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	vars := mux.Vars(r)
 
-	name, err := url.PathUnescape(vars["source"])
+	name, err := url.PathUnescape(r.PathValue("source"))
 	if err != nil {
 		ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
 		return
 	}
 
-	err = s.db.SourcesDataDelete(ctx, name, path.Join(vars["path"], "data.json"), s.auth(r))
+	err = s.db.SourcesDataDelete(ctx, name, path.Join(r.PathValue("path"), "data.json"), s.auth(r))
 	if err != nil {
 		errorAuto(w, err)
 		return
@@ -310,9 +316,8 @@ func (s *Server) v1StacksList(w http.ResponseWriter, r *http.Request) {
 // v1StacksGet handles GET /v1/stacks/{stack}
 func (s *Server) v1StacksGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	vars := mux.Vars(r)
 
-	name, err := url.PathUnescape(vars["stack"])
+	name, err := url.PathUnescape(r.PathValue("stack"))
 	if err != nil {
 		ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
 		return
@@ -331,9 +336,8 @@ func (s *Server) v1StacksGet(w http.ResponseWriter, r *http.Request) {
 // v1StacksPut handles PUT /v1/stacks/{stack}
 func (s *Server) v1StacksPut(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	vars := mux.Vars(r)
 
-	name, err := url.PathUnescape(vars["stack"])
+	name, err := url.PathUnescape(r.PathValue("stack"))
 	if err != nil {
 		ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
 		return
@@ -460,23 +464,21 @@ func newJSONDecoder(r io.Reader) *json.Decoder {
 	return decoder
 }
 
-func authenticationMiddleware(db *database.Database) func(http.Handler) http.Handler {
-	return func(h http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			apiKey, err := extractBearerToken(r)
-			if err != nil {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
-			}
+func authenticationMiddleware(db *database.Database, inner http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		apiKey, err := extractBearerToken(r)
+		if err != nil {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
 
-			principalId, err := db.GetPrincipalId(r.Context(), apiKey)
-			if err != nil {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
-			}
+		principalId, err := db.GetPrincipalId(r.Context(), apiKey)
+		if err != nil {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
 
-			h.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), principalKey{}, principalId)))
-		})
+		inner.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), principalKey{}, principalId)))
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/gorilla/mux"
 	"github.com/open-policy-agent/opa/v1/util"
 	"github.com/testcontainers/testcontainers-go"
 
@@ -626,14 +626,14 @@ func initTestDB(t *testing.T, db *database.Database) *database.Database {
 type testServer struct {
 	t      *testing.T
 	srv    *Server
-	router *mux.Router
+	router *http.ServeMux
 	s      *httptest.Server
 }
 
 func initTestServer(t *testing.T, db *database.Database) *testServer {
 	var ts testServer
 	ts.t = t
-	ts.router = mux.NewRouter()
+	ts.router = http.NewServeMux()
 	ts.srv = New().WithDatabase(db).WithRouter(ts.router)
 	ts.srv.Init()
 	ts.s = httptest.NewServer(ts.router)


### PR DESCRIPTION
## What changed?

This PR migrates the server from using `gorilla/mux` to using the stdlib's `net/http` [`ServeMux` type](https://pkg.go.dev/net/http#ServeMux). A few minor changes were needed in the handlers to extract the path wildcard vars.

Resolves: #92 