### PR TITLE
Consider non-2XX status codes as errors in httpsync

### DIFF
--- a/internal/httpsync/httpsync.go
+++ b/internal/httpsync/httpsync.go
@@ -49,8 +49,11 @@ func (s *HttpDataSynchronizer) Execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
 	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("unsuccessful status code %d", resp.StatusCode)
+	}
 
 	_, err = io.Copy(f, resp.Body)
 	return err

--- a/internal/httpsync/httpsync_test.go
+++ b/internal/httpsync/httpsync_test.go
@@ -39,3 +39,49 @@ func TestHTTPDataSynchronizer(t *testing.T) {
 		t.Fatal("downloaded data does not match expected contents")
 	}
 }
+
+func TestHTTPDataSynchronizer_Error_BadStatusCode(t *testing.T) {
+	currentContents := `{ "previous": "content" }`
+	errorResponseBody := `{"error": "value"}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		w.WriteHeader(http.StatusBadRequest)
+		_, err := w.Write([]byte(errorResponseBody))
+		if err != nil {
+			http.Error(w, "failed to write response", http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	dir := path.Join(t.TempDir(), "foo")
+	err := os.Mkdir(dir, 0755)
+	if err != nil {
+		t.Fatalf("failed to create base dir: %s", err.Error())
+	}
+	file := path.Join(dir, "test.json")
+	err = os.WriteFile(file, []byte(currentContents), 0666)
+	if err != nil {
+		t.Fatalf("failed to write current contents: %s", err.Error())
+	}
+
+	synchronizer := New(file, ts.URL, nil, nil)
+	err = synchronizer.Execute(context.Background())
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	expectedError := "unsuccessful status code 400"
+	if err.Error() != expectedError {
+		t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+	}
+
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("expected no error while reading file, got: %v", err)
+	}
+
+	if len(data) != 0 {
+		t.Fatal("downloaded data should be empty after an error")
+	}
+}


### PR DESCRIPTION
Currently if the request done in `httpsync` results in a non-2xx status code, the result is still written into the data. This leads to issues when you still return JSON for error responses, as the error response will still be included in the bundle.

This PR changes this to return an error in these cases. It could be made even more strict to just allow `200` as a successful status code.