### PR TITLE
authz_test: make tests repeatable, fix flaky TestPartialStringArgs

### DIFF
--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -1,23 +1,28 @@
 package authz
 
 import (
-	"context"
 	"database/sql"
-	"fmt"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	_ "modernc.org/sqlite"
+
+	"github.com/styrainc/opa-control-plane/internal/test/dbs"
 )
 
 func TestPartialStringArgs(t *testing.T) {
-	result, err := Partial(context.Background(), Access{Principal: "bob", Resource: "sources", Permission: "sources.view", Name: "x123"}, map[string]ColumnRef{"input.name": {Table: "sources", Column: "name"}})
+	// NOTE(sr): Don't use the cache here (Partial, uppercase 'P'), as it'll make running this
+	// test multiple times meaningless.
+	result, err := partial(t.Context(), Access{Principal: "bob", Resource: "sources", Permission: "sources.view", Name: "x123"}, map[string]ColumnRef{"input.name": {Table: "sources", Column: "name"}})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	cond, args := result.SQL(func(int) string { return "?" }, nil)
-	expCond := `EXISTS (SELECT 1 FROM resource_permissions WHERE resource_permissions.name=sources.name AND ?=resource_permissions.resource AND ?=resource_permissions.principal_id AND ?=resource_permissions.permission) OR EXISTS (SELECT 1 FROM resource_permissions WHERE resource_permissions.name=sources.name AND ?=resource_permissions.resource AND ?=resource_permissions.principal_id AND resource_permissions.role=?) OR EXISTS (SELECT 1 FROM principals WHERE ?=principals.id AND principals.role=?) OR EXISTS (SELECT 1 FROM principals WHERE ?=principals.id AND principals.role=?)`
+	expCond := `EXISTS (SELECT 1 FROM resource_permissions WHERE resource_permissions.name=sources.name AND ?=resource_permissions.resource AND ?=resource_permissions.principal_id AND ?=resource_permissions.permission) ` +
+		`OR EXISTS (SELECT 1 FROM resource_permissions WHERE resource_permissions.name=sources.name AND ?=resource_permissions.resource AND ?=resource_permissions.principal_id AND resource_permissions.role=?) ` +
+		`OR EXISTS (SELECT 1 FROM principals WHERE ?=principals.id AND principals.role=?) ` +
+		`OR EXISTS (SELECT 1 FROM principals WHERE ?=principals.id AND principals.role=?)`
 	if cond != expCond {
 		t.Fatalf("unexpected condition\n\ngot: %q\n\nexp: %q", cond, expCond)
 	}
@@ -28,45 +33,45 @@ func TestPartialStringArgs(t *testing.T) {
 		"sources",
 		"bob",
 		"owner",
-		"bob",
-		"administrator",
-		"bob",
-		"viewer",
 	}
-	if !reflect.DeepEqual(expArgs, args) {
-		t.Fatalf("unexpected args\n\ngot: %v\n\nexp: %v", args, expArgs)
+	if diff := cmp.Diff(expArgs, args[:6]); diff != "" {
+		t.Fatal("unexpected first 6 args (-want, +got)", diff)
+	}
+
+	expBob1 := []any{
+		"bob", "administrator",
+		"bob", "viewer",
+	}
+	expBob2 := []any{
+		"bob", "viewer",
+		"bob", "administrator",
+	}
+	if diff1, diff2 := cmp.Diff(expBob1, args[6:]), cmp.Diff(expBob2, args[6:]); diff1 != "" && diff2 != "" {
+		t.Fatal("unexpected last 4 args (-want, +got)", diff1, diff2)
 	}
 }
 
 func TestPartial(t *testing.T) {
-	db, err := sql.Open("sqlite", "file::memory:?cache=shared")
+	db, err := sql.Open("sqlite", dbs.MemoryDBName())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	defer db.Close()
 
-	if _, err := db.Exec("CREATE TABLE sources (name TEXT)"); err != nil {
-		t.Fatal(err)
+	query := func(query string) {
+		t.Helper()
+		if _, err := db.ExecContext(t.Context(), query); err != nil {
+			t.Fatal(err)
+		}
 	}
-	if _, err := db.Exec("CREATE TABLE principals (id TEXT, role TEXT)"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := db.Exec("CREATE TABLE resource_permissions (name TEXT, resource TEXT, principal_id TEXT, role TEXT, permission TEXT)"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := db.Exec("INSERT INTO sources (name) VALUES ('source')"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := db.Exec("INSERT INTO principals (id, role) VALUES ('alice', 'administrator')"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := db.Exec("INSERT INTO principals (id, role) VALUES ('bob', 'viewer')"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := db.Exec("INSERT INTO resource_permissions (name, resource, principal_id, role, permission) VALUES ('source', 'sources', 'bob', 'viewer', 'sources.viewer')"); err != nil {
-		t.Fatal(err)
-	}
+	query("CREATE TABLE sources (name TEXT)")
+	query("CREATE TABLE principals (id TEXT, role TEXT)")
+	query("CREATE TABLE resource_permissions (name TEXT, resource TEXT, principal_id TEXT, role TEXT, permission TEXT)")
+	query("INSERT INTO sources (name) VALUES ('source')")
+	query("INSERT INTO principals (id, role) VALUES ('alice', 'administrator')")
+	query("INSERT INTO principals (id, role) VALUES ('bob', 'viewer')")
+	query("INSERT INTO resource_permissions (name, resource, principal_id, role, permission) VALUES ('source', 'sources', 'bob', 'viewer', 'sources.viewer')")
 
 	testCases := []struct {
 		name                string
@@ -104,13 +109,13 @@ func TestPartial(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := Partial(context.Background(), tc.access, tc.extraColumnMappings)
+			result, err := Partial(t.Context(), tc.access, tc.extraColumnMappings)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			cond, args := result.SQL(func(int) string { return "?" }, nil)
-			fmt.Println("cond:", cond, "args:", args)
+			t.Log("cond:", cond, "args:", args)
 			rows, err := db.Query("SELECT * FROM sources WHERE "+cond, args...)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/authz/cache_test.go
+++ b/internal/authz/cache_test.go
@@ -5,6 +5,9 @@ import (
 )
 
 func TestCache(t *testing.T) {
+	// reset cache
+	partialCache = newCache(cacheSize)
+
 	expr1 := sqlExprIsNotNull{Column: ColumnRef{Table: "table1", Column: "id1"}}
 	expr2 := sqlExprIsNotNull{Column: ColumnRef{Table: "table2", Column: "id2"}}
 	expr3 := sqlExprIsNotNull{Column: ColumnRef{Table: "table3", Column: "id3"}}

--- a/internal/test/dbs/dbs.go
+++ b/internal/test/dbs/dbs.go
@@ -36,7 +36,7 @@ const sqliteMemoryOnlyDSNFormat = "file:%d?cache=shared&mode=memory"
 // for SQLite, by incrementing this counter.
 var counter atomic.Int32
 
-func memoryDBName() string {
+func MemoryDBName() string {
 	old := counter.Add(1)
 	return fmt.Sprintf(sqliteMemoryOnlyDSNFormat, old)
 }
@@ -50,7 +50,7 @@ func Configs(t *testing.T) map[string]Setup {
 					Database: &config.Database{
 						SQL: &config.SQLDatabase{
 							Driver: "sqlite3",
-							DSN:    memoryDBName(),
+							DSN:    MemoryDBName(),
 						},
 					},
 				}


### PR DESCRIPTION
The assertion in TestPartialStringArgs was checking a certain ordering of the args slice. The first part needs to match, but the second part doesn't. It came down to ordering of the PE result queries. We not check both (equally valid) versions.

This was shadowed by the tests running with the cache -- so multiple evals wouldn't _really evaluate_ the code that yielded the non-deterministic results.