### PR TITLE
database: handle database changes in migrations

### DIFF
--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -14,6 +14,7 @@ import (
 	"github.com/styrainc/opa-control-plane/cmd/internal/flags"
 	"github.com/styrainc/opa-control-plane/internal/config"
 	"github.com/styrainc/opa-control-plane/internal/logging"
+	"github.com/styrainc/opa-control-plane/internal/migrations"
 	"github.com/styrainc/opa-control-plane/internal/progress"
 	"github.com/styrainc/opa-control-plane/internal/service"
 	"github.com/styrainc/opa-control-plane/internal/util"
@@ -26,6 +27,7 @@ type buildParams struct {
 	persistenceDir    string
 	resetPersistence  bool
 	mergeConflictFail bool
+	migrateDB         bool
 	bundleNames       []string
 	logging           logging.Config
 }
@@ -72,16 +74,28 @@ func init() {
 				}
 			}
 
+			// It might be that `opactl build` is connecting to database -- but
+			// the common use is that `opactl build` will just use its own in-memory
+			// sqlite DB. The logic for running migrations is thus: Do as you're told
+			// if you're told; otherwise apply migrations if there is no database
+			// config.
+			migrate := params.migrateDB || config.Database == nil
+
 			svc := service.New().
 				WithPersistenceDir(params.persistenceDir).
 				WithConfig(config).
 				WithBuiltinFS(util.NewEscapeFS(libraries.FS)).
 				WithSingleShot(true).
 				WithLogger(log).
-				WithNoninteractive(params.noninteractive)
+				WithNoninteractive(params.noninteractive).
+				WithMigrateDB(migrate)
+			if err := svc.Init(ctx); err != nil {
+				fmt.Fprintln(os.Stderr, err.Error())
+				os.Exit(1)
+			}
 
 			if err := svc.Run(ctx); err != nil {
-				fmt.Fprintln(os.Stderr, "unexpected error:", err)
+				fmt.Fprintln(os.Stderr, err.Error())
 				os.Exit(1)
 			}
 
@@ -104,6 +118,7 @@ func init() {
 	build.Flags().BoolVarP(&params.mergeConflictFail, "merge-conflict-fail", "", false, "Fail on config merge conflicts")
 	progress.Var(build.Flags(), &params.noninteractive)
 	logging.VarP(build, &params.logging)
+	migrations.Var(build.Flags(), &params.migrateDB)
 
 	cmd.RootCommand.AddCommand(
 		build,

--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -89,11 +89,6 @@ func init() {
 				WithLogger(log).
 				WithNoninteractive(params.noninteractive).
 				WithMigrateDB(migrate)
-			if err := svc.Init(ctx); err != nil {
-				fmt.Fprintln(os.Stderr, err.Error())
-				os.Exit(1)
-			}
-
 			if err := svc.Run(ctx); err != nil {
 				fmt.Fprintln(os.Stderr, err.Error())
 				os.Exit(1)

--- a/cmd/db/db.go
+++ b/cmd/db/db.go
@@ -13,7 +13,6 @@ import (
 )
 
 type migrateParams struct {
-	noninteractive    bool
 	dryrun            bool
 	mergeConflictFail bool
 	configFile        []string

--- a/cmd/db/db.go
+++ b/cmd/db/db.go
@@ -1,0 +1,70 @@
+package db
+
+import (
+	"bytes"
+
+	"github.com/spf13/cobra"
+
+	"github.com/styrainc/opa-control-plane/cmd"
+	"github.com/styrainc/opa-control-plane/cmd/internal/flags"
+	"github.com/styrainc/opa-control-plane/internal/config"
+	"github.com/styrainc/opa-control-plane/internal/logging"
+	"github.com/styrainc/opa-control-plane/internal/migrations"
+)
+
+type migrateParams struct {
+	noninteractive    bool
+	dryrun            bool
+	mergeConflictFail bool
+	configFile        []string
+	logging           logging.Config
+}
+
+func init() {
+	var params migrateParams
+
+	migrate := &cobra.Command{
+		Use:   "migrate",
+		Short: "Run any outstanding database migrations",
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			lc := params.logging
+			log := logging.NewLogger(lc)
+
+			bs, err := config.Merge(params.configFile, params.mergeConflictFail)
+			if err != nil {
+				log.Fatalf("configuration error: %v", err)
+			}
+
+			config, err := config.Parse(bytes.NewBuffer(bs))
+			if err != nil {
+				log.Fatalf("configuration error: %v", err)
+			}
+
+			migrator := migrations.New().
+				WithLogger(log).
+				WithConfig(config.Database).
+				WithMigrate(!params.dryrun)
+
+			if _, err := migrator.Run(ctx); err != nil {
+				log.Fatalf("migrate: %v", err)
+			}
+		},
+	}
+
+	flags.AddConfig(migrate.Flags(), &params.configFile)
+	migrate.Flags().BoolVarP(&params.dryrun, "dry-run", "", false, "Only report outstanding migrations, don't apply them")
+	migrate.Flags().BoolVarP(&params.mergeConflictFail, "merge-conflict-fail", "", false, "Fail on config merge conflicts")
+	logging.VarP(migrate, &params.logging)
+
+	// adding an extra layer to differentiate from `opactl migrate`
+	db := &cobra.Command{
+		Use:   "db",
+		Short: "DB-related commands",
+	}
+	db.AddCommand(migrate)
+
+	cmd.RootCommand.AddCommand(
+		db,
+	)
+}

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/styrainc/opa-control-plane/cmd/internal/flags"
 	"github.com/styrainc/opa-control-plane/internal/config"
 	"github.com/styrainc/opa-control-plane/internal/logging"
+	"github.com/styrainc/opa-control-plane/internal/migrations"
 	"github.com/styrainc/opa-control-plane/internal/server"
 	"github.com/styrainc/opa-control-plane/internal/service"
 	"github.com/styrainc/opa-control-plane/internal/util"
@@ -24,6 +25,7 @@ type runParams struct {
 	persistenceDir    string
 	resetPersistence  bool
 	mergeConflictFail bool
+	migrateDB         bool
 	logging           logging.Config
 }
 
@@ -63,7 +65,12 @@ func init() {
 				WithPersistenceDir(params.persistenceDir).
 				WithConfig(config).
 				WithBuiltinFS(util.NewEscapeFS(libraries.FS)).
-				WithLogger(log)
+				WithLogger(log).
+				WithMigrateDB(params.migrateDB)
+
+			if err := svc.Init(ctx); err != nil {
+				log.Fatalf("initialize service: %v", err)
+			}
 
 			go func() {
 				if err := server.New().WithDatabase(svc.Database()).WithReadiness(svc.Ready).Init().ListenAndServe(params.addr); err != nil {
@@ -83,6 +90,7 @@ func init() {
 	run.Flags().BoolVarP(&params.resetPersistence, "reset-persistence", "", false, "Reset the persistence directory (for development purposes)")
 	run.Flags().BoolVarP(&params.mergeConflictFail, "merge-conflict-fail", "", false, "Fail on config merge conflicts")
 	logging.VarP(run, &params.logging)
+	migrations.Var(run.Flags(), &params.migrateDB)
 
 	cmd.RootCommand.AddCommand(
 		run,

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -68,6 +68,7 @@ func init() {
 				WithLogger(log).
 				WithMigrateDB(params.migrateDB)
 
+			// NOTE(sr): We run Init() separately here because we're passing svc.Database() to server below
 			if err := svc.Init(ctx); err != nil {
 				log.Fatalf("initialize service: %v", err)
 			}

--- a/docs/k8s-manifests.yaml
+++ b/docs/k8s-manifests.yaml
@@ -272,6 +272,7 @@ spec:
         - "--config=/config.d/my-beta-app.yaml"
         - "--config=/config.d/my-shared-datasource.yaml"
         # - "--reset-persistence"                     # Not suitable for production, but useful for testing
+        - "--apply-migrations" # single OCP instance can run migrations on startup, use `opactl db migrate` for out-of-band migrations
         - "--log-level=debug"
         env:
         - name: AWS_ACCESS_KEY_ID

--- a/e2e/cli/build_configuration_error.txtar
+++ b/e2e/cli/build_configuration_error.txtar
@@ -1,9 +1,9 @@
 ! exec $OPACTL build --config config.d/bundle.yml --data-dir tmp
-stderr '^unexpected error: load config failed: upsert bundle "hello-world" failed'
+stderr '^load config failed: upsert bundle "hello-world" failed'
 ! stdout .
 
 ! exec $OPACTL build --config config.d/bundle.yml --data-dir tmp --non-interactive
-stderr '^unexpected error: load config failed: upsert bundle "hello-world" failed'
+stderr '^load config failed: upsert bundle "hello-world" failed'
 ! stdout .
 
 -- config.d/bundle.yml --

--- a/e2e/cli/db_migrate.txtar
+++ b/e2e/cli/db_migrate.txtar
@@ -1,0 +1,37 @@
+exec $OPACTL db migrate --config config.d/no_db.yml --dry-run
+stderr 'WARN'
+stderr 'database has never run migrations'
+! stdout .
+
+# rule of silence
+exec $OPACTL db migrate --config config.d/no_db.yml
+! stderr .
+! stdout .
+
+exec $OPACTL db migrate --config config.d/local_db.yml --log-level debug
+stderr 'Finished 13/u resource_permissions'
+! stdout .
+
+exec $OPACTL db migrate --config config.d/local_db.yml --log-level debug --dry-run
+stderr 'database migrations up to date'
+! stdout .
+
+-- config.d/no_db.yml --
+bundles:
+  a:
+    object_storage:
+      filesystem:
+        path: bundles/a/bundle.tar.gz
+    requirements:
+-- config.d/local_db.yml --
+database:
+  sql:
+    driver: sqlite
+    dsn: ocp_sqlite.db
+bundles:
+  a:
+    object_storage:
+      filesystem:
+        path: bundles/a/bundle.tar.gz
+    requirements:
+

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  ocp:
+    image: ${OCP_IMAGE:-openpolicyagent/opa-control-plane:edge}
+    command:
+      - run
+      - --addr=0.0.0.0:8282
+      - --apply-migrations
+      - --config=/ocp.yml
+      - --data-dir=/tmp
+      - --log-level=debug
+    volumes:
+      - ./ocp.yml:/ocp.yml
+    ports:
+      - 8282:8282
+
+  db:
+    image: postgres:latest
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: sesame
+    volumes:
+      - pgdata:/var/lib/postgresql/data 
+ 
+  # use username 'postgres', password 'sesame' on http://127.0.0.1:8080
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
+ 
+volumes:
+  pgdata:

--- a/examples/docker/ocp.yml
+++ b/examples/docker/ocp.yml
@@ -1,0 +1,9 @@
+tokens:
+  admin:
+    api_key: sesame
+    scopes:
+    - role: administrator
+database:
+  sql:
+    driver: postgres
+    dsn: postgresql://postgres:sesame@db:5432

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
-	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.5.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 // indirect
@@ -25,7 +25,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
-	github.com/aws/aws-sdk-go v1.44.256 // indirect
+	github.com/aws/aws-sdk-go v1.49.6 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.1 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.12 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.7 // indirect
@@ -91,6 +91,8 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
@@ -105,6 +107,7 @@ require (
 	github.com/lestrrat-go/jwx/v3 v3.0.10 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
+	github.com/lib/pq v1.10.9 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -217,6 +220,7 @@ require (
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/gobwas/glob v0.2.3
+	github.com/golang-migrate/migrate/v4 v4.19.0
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/jackc/pgx/v5 v5.7.6

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.0 
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.0/go.mod h1:DWAciXemNf++PQJLeXUB4HHH5OpsAh12HZnu2wXE1jA=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.1 h1:lhZdRq7TIx0GJQvSyX2Si406vrYsov2FXGp/RnSEtcs=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.1/go.mod h1:8cl44BDmi+effbARHMQjgOKA2AYvcohNm7KEt42mSV8=
-github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
-github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
+github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.5.0 h1:XkkQbfMyuH2jTSjQjSoihryI8GINRcs4xp8lNawg0FI=
@@ -69,8 +69,9 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/aws-sdk-go v1.44.256 h1:O8VH+bJqgLDguqkH/xQBFz5o/YheeZqgcOYIgsTVWY4=
 github.com/aws/aws-sdk-go v1.44.256/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.49.6 h1:yNldzF5kzLBRvKlKz1S0bkvc2+04R1kt13KfBWQBfFA=
+github.com/aws/aws-sdk-go v1.49.6/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.39.2 h1:EJLg8IdbzgeD7xgvZ+I8M1e0fL0ptn/M47lianzth0I=
 github.com/aws/aws-sdk-go-v2 v1.39.2/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.1 h1:i8p8P4diljCr60PpJp6qZXNlgX4m2yQFpYk+9ZT+J4E=
@@ -168,6 +169,8 @@ github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa5
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/dhui/dktest v0.4.6 h1:+DPKyScKSEp3VLtbMDHcUq6V5Lm5zfZZVb0Sk7Ahom4=
+github.com/dhui/dktest v0.4.6/go.mod h1:JHTSYDtKkvFNFHJKqCzVzqXecyv+tKt8EzceOmQOgbU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
@@ -242,6 +245,8 @@ github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXe
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/golang-migrate/migrate/v4 v4.19.0 h1:RcjOnCGz3Or6HQYEJ/EEVLfWnmw9KnoigPSjzhCuaSE=
+github.com/golang-migrate/migrate/v4 v4.19.0/go.mod h1:9dyEcu+hO+G9hPSw8AIg50yg622pXJsoHItQnDGZkI0=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
@@ -270,6 +275,11 @@ github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81
 github.com/googleapis/gax-go/v2 v2.15.0/go.mod h1:zVVkkxAQHa1RQpg9z2AUCMnKhi0Qld9rcmyfL1OZhoc=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 h1:X5VWvz21y3gzm9Nw/kaUeku/1+uBhcekkmy4IkffJww=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1/go.mod h1:Zanoh4+gvIgluNqcfMVTJueD4wSS5hT7zTt4Mrutd90=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
+github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/iancoleman/orderedmap v0.3.0 h1:5cbR2grmZR/DiVt+VJopEhtVs9YGInGIxAoMJn+Ichc=
@@ -366,6 +376,7 @@ github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdh
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo/v2 v2.22.2 h1:/3X8Panh8/WwhU/3Ssa6rCKqPLuAkVY2I0RoyDLySlU=
 github.com/onsi/ginkgo/v2 v2.22.2/go.mod h1:oeMosUL+8LtarXBHu/c0bx2D/K9zyQ6uX3cTyztHwsk=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -39,11 +39,10 @@ const SQLiteMemoryOnlyDSN = "file::memory:?cache=shared"
 
 // Database implements the database operations. It will hide any differences between the varying SQL databases from the rest of the codebase.
 type Database struct {
-	db      *sql.DB
-	config  *config.Database
-	kind    int
-	log     *logging.Logger
-	migrate bool
+	db     *sql.DB
+	config *config.Database
+	kind   int
+	log    *logging.Logger
 }
 
 func (d *Database) DB() *sql.DB {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/styrainc/opa-control-plane/internal/config"
 	"github.com/styrainc/opa-control-plane/internal/database"
-	"github.com/styrainc/opa-control-plane/internal/service"
+	"github.com/styrainc/opa-control-plane/internal/migrations"
 	"github.com/styrainc/opa-control-plane/internal/test/dbs"
 	"github.com/testcontainers/testcontainers-go"
 )
@@ -26,8 +26,7 @@ func TestDatabase(t *testing.T) {
 				t.Cleanup(databaseConfig.Cleanup(t, ctr))
 			}
 
-			db := service.New().WithConfig(databaseConfig.Database(t, ctr)).Database()
-			err := db.InitDB(ctx)
+			db, err := migrations.New().WithConfig(databaseConfig.Database(t, ctr).Database).WithMigrate(true).Run(ctx)
 			if err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}

--- a/internal/database/principal_test.go
+++ b/internal/database/principal_test.go
@@ -1,54 +1,68 @@
 package database_test
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/styrainc/opa-control-plane/internal/database"
 	"github.com/styrainc/opa-control-plane/internal/migrations"
+	"github.com/styrainc/opa-control-plane/internal/test/dbs"
+
+	"github.com/testcontainers/testcontainers-go"
 )
 
-// TODO(sr): run these tests with all databases.
 func TestCascadingDeletesForPrincipalsAndResourcePermissions(t *testing.T) {
 	ctx := t.Context()
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				t.Cleanup(databaseConfig.Cleanup(t, ctr))
+			}
 
-	db, err := migrations.New().WithMigrate(true).Run(ctx)
-	if err != nil {
-		t.Fatal(err)
+			db, err := migrations.New().WithConfig(databaseConfig.Database(t, ctr).Database).WithMigrate(true).Run(ctx)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			if err := db.UpsertPrincipal(ctx, database.Principal{Id: "test", Role: "administrator"}); err != nil {
+				t.Fatal(err)
+			}
+
+			var count int
+
+			if err := db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_permissions").Scan(&count); err != nil {
+				t.Fatal(err)
+			} else if count != 0 {
+				t.Fatal("expected count to be zero")
+			}
+
+			for i := range 100 { // arbitrary number of perms
+				if _, err := db.DB().ExecContext(ctx,
+					fmt.Sprintf("INSERT INTO resource_permissions (name, resource, principal_id, role) VALUES ('%s', '%s', '%s', '%s')", "xyz"+strconv.Itoa(i), "bundles", "test", "owner"),
+				); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_permissions").Scan(&count); err != nil {
+				t.Fatal(err)
+			} else if count != 100 {
+				t.Fatal("expected count to be 100")
+			}
+
+			if _, err := db.DB().Exec("DELETE FROM principals WHERE id ='test'"); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_permissions").Scan(&count); err != nil {
+				t.Fatal(err)
+			} else if count != 0 {
+				t.Fatal("expected count to be zero")
+			}
+		})
 	}
-
-	if err := db.UpsertPrincipal(ctx, database.Principal{Id: "test", Role: "administrator"}); err != nil {
-		t.Fatal(err)
-	}
-
-	var count int
-
-	if err := db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_permissions").Scan(&count); err != nil {
-		t.Fatal(err)
-	} else if count != 0 {
-		t.Fatal("expected count to be zero")
-	}
-
-	for i := range 100 { // arbitrary number of perms
-		if _, err := db.DB().ExecContext(ctx, "INSERT INTO resource_permissions (name, resource, principal_id, role) VALUES (?, ?, ?, ?)", "xyz"+strconv.Itoa(i), "bundles", "test", "owner"); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	if err := db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_permissions").Scan(&count); err != nil {
-		t.Fatal(err)
-	} else if count != 100 {
-		t.Fatal("expected count to be 100")
-	}
-
-	if _, err := db.DB().Exec("DELETE FROM principals WHERE id = ?", "test"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_permissions").Scan(&count); err != nil {
-		t.Fatal(err)
-	} else if count != 0 {
-		t.Fatal("expected count to be zero")
-	}
-
 }

--- a/internal/database/principal_test.go
+++ b/internal/database/principal_test.go
@@ -1,49 +1,51 @@
-package database
+package database_test
 
 import (
-	"context"
 	"strconv"
 	"testing"
+
+	"github.com/styrainc/opa-control-plane/internal/database"
+	"github.com/styrainc/opa-control-plane/internal/migrations"
 )
 
+// TODO(sr): run these tests with all databases.
 func TestCascadingDeletesForPrincipalsAndResourcePermissions(t *testing.T) {
+	ctx := t.Context()
 
-	ctx := context.Background()
-
-	var db Database
-	if err := db.InitDB(ctx); err != nil {
+	db, err := migrations.New().WithMigrate(true).Run(ctx)
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := db.UpsertPrincipal(ctx, Principal{Id: "test", Role: "administrator"}); err != nil {
+	if err := db.UpsertPrincipal(ctx, database.Principal{Id: "test", Role: "administrator"}); err != nil {
 		t.Fatal(err)
 	}
 
 	var count int
 
-	if err := db.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_permissions").Scan(&count); err != nil {
+	if err := db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_permissions").Scan(&count); err != nil {
 		t.Fatal(err)
 	} else if count != 0 {
 		t.Fatal("expected count to be zero")
 	}
 
 	for i := range 100 { // arbitrary number of perms
-		if _, err := db.db.ExecContext(ctx, "INSERT INTO resource_permissions (name, resource, principal_id, role) VALUES (?, ?, ?, ?)", "xyz"+strconv.Itoa(i), "bundles", "test", "owner"); err != nil {
+		if _, err := db.DB().ExecContext(ctx, "INSERT INTO resource_permissions (name, resource, principal_id, role) VALUES (?, ?, ?, ?)", "xyz"+strconv.Itoa(i), "bundles", "test", "owner"); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	if err := db.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_permissions").Scan(&count); err != nil {
+	if err := db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_permissions").Scan(&count); err != nil {
 		t.Fatal(err)
 	} else if count != 100 {
 		t.Fatal("expected count to be 100")
 	}
 
-	if _, err := db.db.Exec("DELETE FROM principals WHERE id = ?", "test"); err != nil {
+	if _, err := db.DB().Exec("DELETE FROM principals WHERE id = ?", "test"); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := db.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_permissions").Scan(&count); err != nil {
+	if err := db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_permissions").Scan(&count); err != nil {
 		t.Fatal(err)
 	} else if count != 0 {
 		t.Fatal("expected count to be zero")

--- a/internal/migrations/initial.go
+++ b/internal/migrations/initial.go
@@ -10,7 +10,9 @@ import (
 
 func Migrations(dialect string) (fs.FS, error) {
 	ns := util.Namespace()
-	ns.Bind(".", initialSchemaFS(dialect))
+	if err := ns.Bind(".", initialSchemaFS(dialect)); err != nil {
+		return nil, err
+	}
 	return ns, nil
 }
 
@@ -36,7 +38,7 @@ func initialSchemaFS(dialect string) fs.FS {
 // migrations were introduced. THESE MAY NOT BE CHANGED, as the migrations machinery
 // would fall apart for anyone who already applied these migrations.
 // They are the basis of all further migrations. We keep them here because it's
-// convienent to lookup the tables and there relations in one place -- the initial
+// convenient to lookup the tables and there relations in one place -- the initial
 // migrations are generated from for each of the dialects we support.
 var schema = []sqlTable{
 	createSQLTable("bundles").

--- a/internal/migrations/initial.go
+++ b/internal/migrations/initial.go
@@ -1,11 +1,43 @@
-package database
+package migrations
 
 import (
 	"fmt"
-	"slices"
+	"io/fs"
 	"strings"
+
+	"github.com/styrainc/opa-control-plane/internal/util"
 )
 
+func Migrations(dialect string) (fs.FS, error) {
+	ns := util.Namespace()
+	ns.Bind(".", initialSchemaFS(dialect))
+	return ns, nil
+}
+
+func initialSchemaFS(dialect string) fs.FS {
+	var kind int
+	switch dialect {
+	case "postgresql":
+		kind = postgres
+	case "mysql":
+		kind = mysql
+	case "sqlite":
+		kind = sqlite
+	}
+	m := make(map[string]string, len(schema))
+	for i, tbl := range schema {
+		f := fmt.Sprintf("%03d_%s.up.sql", i, tbl.name)
+		m[f] = tbl.SQL(kind)
+	}
+	return util.MapFS(m)
+}
+
+// schema holds the initial set of database tables, dating back to when database
+// migrations were introduced. THESE MAY NOT BE CHANGED, as the migrations machinery
+// would fall apart for anyone who already applied these migrations.
+// They are the basis of all further migrations. We keep them here because it's
+// convienent to lookup the tables and there relations in one place -- the initial
+// migrations are generated from for each of the dialects we support.
 var schema = []sqlTable{
 	createSQLTable("bundles").
 		IntegerPrimaryKeyAutoincrementColumn("id").
@@ -110,6 +142,12 @@ var schema = []sqlTable{
 		PrimaryKey("name", "resource").
 		ForeignKeyOnDeleteCascade("principal_id", "principals(id)"),
 }
+
+const (
+	sqlite = iota
+	postgres
+	mysql
+)
 
 type sqlColumn struct {
 	Name                    string
@@ -332,34 +370,4 @@ func (t sqlTable) SQL(kind int) string {
 
 	return `CREATE TABLE IF NOT EXISTS ` + t.name + ` (
 			` + strings.Join(c, ",\n") + `);`
-}
-
-// checkTablePrimaryKey checks if the primary key columns for a table match the schema.
-// It serves to validate that the primary key columns specified in the upsert operation are valid.
-func checkTablePrimaryKey(table string, primaryKey []string) error {
-	for _, t := range schema {
-		if t.name == table {
-			if len(primaryKey) == 1 {
-				for _, col := range t.columns {
-					if col.Name == primaryKey[0] && (col.PrimaryKey || col.Unique) {
-						return nil
-					}
-				}
-
-				return fmt.Errorf("primary key column %q not found in table %q", primaryKey[0], table)
-			}
-
-			if len(primaryKey) != len(t.primaryKeyColumns) {
-				return fmt.Errorf("invalid number of primary key columns for table %q: expected %d, got %d", table, len(t.primaryKeyColumns), len(primaryKey))
-			}
-
-			if !slices.Equal(primaryKey, t.primaryKeyColumns) {
-				return fmt.Errorf("primary key columns %v do not match expected columns %v for table %q", primaryKey, t.primaryKeyColumns, table)
-			}
-
-			return nil
-		}
-	}
-
-	return fmt.Errorf("table %q not found in schema", table)
 }

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -1,0 +1,152 @@
+// Package migrations is for database migrations! This is not related to
+// the `opactl migrate` command at all.
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang-migrate/migrate/v4"
+	migrate_database "github.com/golang-migrate/migrate/v4/database"
+	migrate_mysql "github.com/golang-migrate/migrate/v4/database/mysql"
+	migrate_postgres "github.com/golang-migrate/migrate/v4/database/postgres"
+	migrate_sqlite "github.com/golang-migrate/migrate/v4/database/sqlite"
+	migrate_source "github.com/golang-migrate/migrate/v4/source"
+	migrate_iofs "github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/spf13/pflag"
+
+	"github.com/styrainc/opa-control-plane/internal/config"
+	"github.com/styrainc/opa-control-plane/internal/database"
+	"github.com/styrainc/opa-control-plane/internal/logging"
+)
+
+type Migrator struct {
+	config  *config.Database
+	log     *logging.Logger
+	migrate bool
+}
+
+func New() *Migrator {
+	return &Migrator{}
+}
+
+func (m *Migrator) WithConfig(db *config.Database) *Migrator {
+	m.config = db
+	return m
+}
+
+// WithMigrate causes migrations to be applied. Without this, we will log (INFO)
+// the number of pending migrations only.
+func (m *Migrator) WithMigrate(yes bool) *Migrator {
+	m.migrate = yes
+	return m
+}
+
+func (m *Migrator) WithLogger(log *logging.Logger) *Migrator {
+	m.log = log
+	return m
+}
+
+func (m *Migrator) Run(ctx context.Context) (*database.Database, error) {
+	db := (&database.Database{}).WithConfig(m.config).WithLogger(m.log)
+	if err := db.InitDB(ctx); err != nil {
+		return nil, fmt.Errorf("migrate: %w", err)
+	}
+
+	dialect, err := db.Dialect()
+	if err != nil {
+		return nil, err
+	}
+
+	var driver migrate_database.Driver
+	switch dialect {
+	case "sqlite":
+		driver, err = migrate_sqlite.WithInstance(db.DB(), &migrate_sqlite.Config{})
+	case "postgresql":
+		driver, err = migrate_postgres.WithInstance(db.DB(), &migrate_postgres.Config{})
+	case "mysql":
+		driver, err = migrate_mysql.WithInstance(db.DB(), &migrate_mysql.Config{})
+	default:
+		// future-proofing, this shouldn't happen with the result of db.Dialect()
+		err = fmt.Errorf("unknown dialect %s", dialect)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("migrate: %w", err)
+	}
+
+	fsys, err := Migrations(dialect)
+	if err != nil {
+		return nil, err
+	}
+
+	d, err := migrate_iofs.New(fsys, ".")
+	if err != nil {
+		return nil, err
+	}
+
+	latest := findLatest(d)
+
+	mi, err := migrate.NewWithInstance("iofs", d, dialect, driver)
+	if err != nil {
+		return nil, err
+	}
+	mi.Log = wrap{m.log}
+
+	if !m.migrate { // log pending migrations only
+		ver, _, err := mi.Version()
+		switch err {
+		case nil:
+			switch {
+			case ver == latest:
+				m.log.Debug("database migrations up to date")
+			case ver > latest:
+				m.log.Warn("database migrations are %d steps ahead (old binary?)", ver-latest)
+			case ver < latest:
+				m.log.Warnf("%d database migrations pending", ver-latest)
+			}
+		case migrate.ErrNilVersion:
+			m.log.Warn("database has never run migrations") // perhaps it's in progress, so we won't error out
+		default: // some error occurred
+			return nil, err
+		}
+		return db, nil
+	}
+
+	if err := mi.Up(); err != nil && err != migrate.ErrNoChange {
+		return nil, fmt.Errorf("database migrations: %w", err)
+	}
+	return db, nil
+}
+
+func Var(fs *pflag.FlagSet, yes *bool) {
+	fs.BoolVarP(yes, "apply-migrations", "", false, "Apply database migrations on startup")
+}
+
+func findLatest(d migrate_source.Driver) uint {
+	// NB(sr): The docs seem to me misleading, and I can't find the right
+	// error to use here -- so let's just return `i` on any error. It should
+	// be OK given that we're only operating on an fs.FS.
+	var prev uint = 0
+	for next, err := d.First(); ; next, err = d.Next(prev) {
+		if err != nil {
+			return prev
+		}
+		prev = next
+	}
+}
+
+// wrap wires our logger into migrate's logger. We'll log every migration-related
+// messages with level DEBUG, and hardcode "verbose" to true. That way, you'll
+// see no migration-related logs in standard operations, but you can see as much
+// as it'll give us when using log-level debug.
+type wrap struct {
+	log *logging.Logger
+}
+
+func (w wrap) Printf(fmt string, args ...any) {
+	w.log.Debugf(fmt, args...)
+}
+
+func (wrap) Verbose() bool {
+	return true
+}

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -135,7 +135,7 @@ func findLatest(d migrate_source.Driver) uint {
 	}
 }
 
-// wrap wires our logger into migrate's logger. We'll log every migration-related
+// wrap wires our logger into migrate's logger. We'll log all migration-related
 // messages with level DEBUG, and hardcode "verbose" to true. That way, you'll
 // see no migration-related logs in standard operations, but you can see as much
 // as it'll give us when using log-level debug.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/styrainc/opa-control-plane/internal/config"
 	"github.com/styrainc/opa-control-plane/internal/database"
+	"github.com/styrainc/opa-control-plane/internal/migrations"
 	"github.com/styrainc/opa-control-plane/internal/server/types"
 	"github.com/styrainc/opa-control-plane/internal/test/dbs"
 )
@@ -31,8 +32,7 @@ func TestServerSourcesData(t *testing.T) {
 				t.Cleanup(databaseConfig.Cleanup(t, ctr))
 			}
 
-			db := (&database.Database{}).WithConfig(databaseConfig.Database(t, ctr).Database)
-			db = initTestDB(t, db)
+			db := initTestDB(t, databaseConfig.Database(t, ctr).Database)
 			ts := initTestServer(t, db)
 			defer ts.Close()
 
@@ -154,8 +154,7 @@ func TestServerSecretsOwners(t *testing.T) {
 				t.Cleanup(databaseConfig.Cleanup(t, ctr))
 			}
 
-			db := (&database.Database{}).WithConfig(databaseConfig.Database(t, ctr).Database)
-			db = initTestDB(t, db)
+			db := initTestDB(t, databaseConfig.Database(t, ctr).Database)
 			ts := initTestServer(t, db)
 			defer ts.Close()
 
@@ -241,8 +240,7 @@ func TestServerBundleOwners(t *testing.T) {
 				t.Cleanup(databaseConfig.Cleanup(t, ctr))
 			}
 
-			db := (&database.Database{}).WithConfig(databaseConfig.Database(t, ctr).Database)
-			db = initTestDB(t, db)
+			db := initTestDB(t, databaseConfig.Database(t, ctr).Database)
 			ts := initTestServer(t, db)
 			defer ts.Close()
 
@@ -343,9 +341,7 @@ func TestServerSourceOwners(t *testing.T) {
 				t.Cleanup(databaseConfig.Cleanup(t, ctr))
 			}
 
-			db := (&database.Database{}).WithConfig(databaseConfig.Database(t, ctr).Database)
-			db = initTestDB(t, db)
-
+			db := initTestDB(t, databaseConfig.Database(t, ctr).Database)
 			ts := initTestServer(t, db)
 			defer ts.Close()
 
@@ -438,9 +434,7 @@ func TestSourcesDatasourcesSecrets(t *testing.T) {
 				t.Cleanup(databaseConfig.Cleanup(t, ctr))
 			}
 
-			db := (&database.Database{}).WithConfig(databaseConfig.Database(t, ctr).Database)
-			db = initTestDB(t, db)
-
+			db := initTestDB(t, databaseConfig.Database(t, ctr).Database)
 			ts := initTestServer(t, db)
 			defer ts.Close()
 
@@ -569,8 +563,7 @@ func TestServerStackOwners(t *testing.T) {
 				t.Cleanup(databaseConfig.Cleanup(t, ctr))
 			}
 
-			db := (&database.Database{}).WithConfig(databaseConfig.Database(t, ctr).Database)
-			db = initTestDB(t, db)
+			db := initTestDB(t, databaseConfig.Database(t, ctr).Database)
 			ts := initTestServer(t, db)
 			defer ts.Close()
 
@@ -661,9 +654,7 @@ func TestServerSourcePagination(t *testing.T) {
 				t.Cleanup(databaseConfig.Cleanup(t, ctr))
 			}
 
-			db := (&database.Database{}).WithConfig(databaseConfig.Database(t, ctr).Database)
-			db = initTestDB(t, db)
-
+			db := initTestDB(t, databaseConfig.Database(t, ctr).Database)
 			ts := initTestServer(t, db)
 			defer ts.Close()
 
@@ -742,12 +733,13 @@ func TestServerHealthEndpoint(t *testing.T) {
 
 }
 
-func initTestDB(t *testing.T, db *database.Database) *database.Database {
+func initTestDB(t *testing.T, config *config.Database) *database.Database {
 	t.Helper()
-	if db == nil {
-		db = &database.Database{}
-	}
-	if err := db.InitDB(t.Context()); err != nil {
+	db, err := migrations.New().
+		WithConfig(config).
+		WithMigrate(true).
+		Run(t.Context())
+	if err != nil {
 		t.Fatal(err)
 	}
 	return db

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/styrainc/opa-control-plane/internal/gitsync"
 	"github.com/styrainc/opa-control-plane/internal/httpsync"
 	"github.com/styrainc/opa-control-plane/internal/logging"
+	"github.com/styrainc/opa-control-plane/internal/migrations"
 	"github.com/styrainc/opa-control-plane/internal/pool"
 	"github.com/styrainc/opa-control-plane/internal/progress"
 	"github.com/styrainc/opa-control-plane/internal/s3"
@@ -46,6 +47,7 @@ type Service struct {
 	report         *Report
 	log            *logging.Logger
 	noninteractive bool
+	migrateDB      bool
 }
 
 type Report struct {
@@ -96,6 +98,7 @@ func New() *Service {
 		workers:        make(map[string]*BundleWorker),
 		failures:       make(map[string]Status),
 		noninteractive: true,
+		migrateDB:      false,
 	}
 }
 
@@ -135,11 +138,16 @@ func (s *Service) WithNoninteractive(yes bool) *Service {
 	return s
 }
 
-func (s *Service) Run(ctx context.Context) error {
-	if err := s.initDB(ctx); err != nil {
-		return err
-	}
+func (s *Service) WithMigrateDB(yes bool) *Service {
+	s.migrateDB = yes
+	return s
+}
 
+func (s *Service) Init(ctx context.Context) error {
+	return s.initDB(ctx)
+}
+
+func (s *Service) Run(ctx context.Context) error {
 	defer s.database.CloseDB()
 
 	s.readyMutex.Lock()
@@ -177,20 +185,17 @@ shutdown:
 		for _, w := range s.workers {
 			s.report.Bundles[w.bundleConfig.Name] = w.status
 		}
-		for b, status := range s.failures {
-			s.report.Bundles[b] = status
-		}
+		maps.Copy(s.report.Bundles, s.failures)
 	}
 
 	return nil
-
 }
 
 func (s *Service) Report() *Report {
 	return s.report
 }
 
-func (s *Service) Ready(_ context.Context) error {
+func (s *Service) Ready(context.Context) error {
 	s.readyMutex.Lock()
 	defer s.readyMutex.Unlock()
 	if s.ready {
@@ -203,9 +208,15 @@ func (s *Service) initDB(ctx context.Context) error {
 	bar := progress.New(s.noninteractive, -1, "loading configuration")
 	defer bar.Finish()
 
-	if err := s.database.InitDB(ctx); err != nil {
+	db, err := migrations.New().
+		WithConfig(s.config.Database).
+		WithLogger(s.log).
+		WithMigrate(s.migrateDB).
+		Run(ctx)
+	if err != nil {
 		return err
 	}
+	s.database = *db
 
 	if err := s.database.UpsertPrincipal(ctx, database.Principal{Id: internalPrincipal, Role: "administrator"}); err != nil {
 		return err

--- a/internal/service/service_e2e_test.go
+++ b/internal/service/service_e2e_test.go
@@ -106,7 +106,11 @@ func TestService(t *testing.T) {
 					WithPersistenceDir(persistenceDir).
 					WithBuiltinFS(util.NewEscapeFS(libraries.FS)).
 					WithSingleShot(true).
+					WithMigrateDB(true).
 					WithLogger(logging.NewLogger(logging.Config{Level: logging.LevelDebug}))
+				if err := svc.Init(ctx); err != nil {
+					t.Fatal(err)
+				}
 				if err := svc.Run(ctx); err != nil {
 					t.Fatal(err)
 				}

--- a/internal/service/service_e2e_test.go
+++ b/internal/service/service_e2e_test.go
@@ -108,9 +108,6 @@ func TestService(t *testing.T) {
 					WithSingleShot(true).
 					WithMigrateDB(true).
 					WithLogger(logging.NewLogger(logging.Config{Level: logging.LevelDebug}))
-				if err := svc.Init(ctx); err != nil {
-					t.Fatal(err)
-				}
 				if err := svc.Run(ctx); err != nil {
 					t.Fatal(err)
 				}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -206,6 +206,7 @@ func oneshot(t *testing.T, bs []byte, dir string) *service.Service {
 		WithConfig(cfg).
 		WithPersistenceDir(filepath.Join(dir, "data")).
 		WithSingleShot(true).
+		WithMigrateDB(true).
 		WithLogger(log)
 
 	err = svc.Run(context.Background())

--- a/internal/util/mapfs.go
+++ b/internal/util/mapfs.go
@@ -1,0 +1,11 @@
+package util
+
+import (
+	"io/fs"
+
+	"github.com/knieriem/fsutil"
+)
+
+func MapFS(m map[string]string) fs.FS {
+	return fsutil.StringMap(m)
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/styrainc/opa-control-plane/cmd/backtest"
 	_ "github.com/styrainc/opa-control-plane/cmd/build"
 	_ "github.com/styrainc/opa-control-plane/cmd/compare"
+	_ "github.com/styrainc/opa-control-plane/cmd/db"
 	_ "github.com/styrainc/opa-control-plane/cmd/migrate"
 	_ "github.com/styrainc/opa-control-plane/cmd/run"
 	_ "github.com/styrainc/opa-control-plane/cmd/version"


### PR DESCRIPTION
With this change, `opactl run` will do this:
1. if run without a database config (i.e. using the sqlite default), it'll apply migrations
2. otherwise, it'll check the current state of the migrations in the database, with "$latest" the latest migration compiled into the binary,
  a. it will warn about pending migrations  if $current < $latest
  b. it will warn about a stale binary if $current > $latest
  c. attempt to use the database as-is

Migrations can be applied out of band by the operations procedures of the user: `opactl db migrate` will do that. It's safe to run at any time, and should be the first thing you do after pulling a new OCP image.

For simplicity, when you deploy a single OCP that owns its database, you can pass `--apply-migrations` to `opactl run`. It'll then just apply the latest migrations as compiled into the binary. 

Fixes #106.