### PR TITLE
docs(k8s): use correct image and tag in manifest

### DIFF
--- a/docs/k8s-manifests.yaml
+++ b/docs/k8s-manifests.yaml
@@ -259,9 +259,8 @@ spec:
     spec:
       containers:
       - name: opactl
-        image: openpolicyagent/opactl
+        image: openpolicyagent/opa-control-plane:edge
         imagePullPolicy: IfNotPresent
-        command: ["/app/opactl"]
         args:
         - "run"
         - "--addr=0.0.0.0:8282"


### PR DESCRIPTION
The [example Kubernetes manifest](https://www.openpolicyagent.org/docs/ocp/guide-deploy-as-a-service#complete-manifest) referenced a non-existent image, which caused deployments to fail. Update it to the published image and remove the explicit container command so the Deployment uses the CMD from the project Dockerfile.