### PR TITLE
metrics for git syncs and bundle builds

### DIFF
--- a/e2e/cli/run_git_bundle_build.txtar
+++ b/e2e/cli/run_git_bundle_build.txtar
@@ -9,11 +9,11 @@ exec git add .
 exec git commit -m initial-commit
 cd ..
 
-exec $OPACTL run --config config.d/bundle.yml --data-dir tmp &opactl&
+exec $OPACTL run --addr 127.0.0.1:8383 --config config.d/bundle.yml --data-dir tmp1 &opactl&
 ! stderr .
 ! stdout .
 
-exec curl --retry 5 --retry-all-errors http://127.0.0.1:8282/metrics
+exec curl --retry 5 --retry-all-errors http://127.0.0.1:8383/metrics
 
 # assert git sync and bundle build metrics
 stdout 'ocp_git_sync_count_total{repo="./repo/",source="git-data",state="SUCCESS"} 1'

--- a/e2e/cli/run_git_bundle_build.txtar
+++ b/e2e/cli/run_git_bundle_build.txtar
@@ -27,8 +27,6 @@ stdout 'ocp_bundle_build_count_total{bundle="hello-world",state="SUCCESS"} 1'
 
 kill opactl
 
--- repo/unrelated.yaml --
-ignore: me
 -- repo/users/data.json --
 [
   {
@@ -51,5 +49,3 @@ sources:
     git:
       repo: ./repo/
       reference: main
-      excluded_files:
-      - unrelated.yaml

--- a/e2e/cli/run_git_bundle_build.txtar
+++ b/e2e/cli/run_git_bundle_build.txtar
@@ -9,11 +9,11 @@ exec git add .
 exec git commit -m initial-commit
 cd ..
 
-exec $OPACTL run --addr 127.0.0.1:8383 --config config.d/bundle.yml --data-dir tmp1 &opactl&
+exec $OPACTL run --addr 127.0.0.1:8283 --config config.d/bundle.yml --data-dir tmp1 &opactl&
 ! stderr .
 ! stdout .
 
-exec curl --retry 5 --retry-all-errors http://127.0.0.1:8383/metrics
+exec curl --retry 5 --retry-all-errors http://127.0.0.1:8283/metrics
 
 # assert git sync and bundle build metrics
 stdout 'ocp_git_sync_count_total{repo="./repo/",source="git-data",state="SUCCESS"} 1'

--- a/e2e/cli/run_git_bundle_build.txtar
+++ b/e2e/cli/run_git_bundle_build.txtar
@@ -1,0 +1,55 @@
+# local example git repo
+cd repo
+env HOME=.
+exec git init .
+exec git branch -m main
+exec git config --global user.name "botbotbot" 
+exec git config --global user.email "bot@bot.bot" 
+exec git add .
+exec git commit -m initial-commit
+cd ..
+
+exec $OPACTL run --config config.d/bundle.yml --data-dir tmp &opactl&
+! stderr .
+! stdout .
+
+exec curl --retry 5 --retry-all-errors http://127.0.0.1:8282/metrics
+
+# assert git sync and bundle build metrics
+stdout 'ocp_git_sync_count_total{repo="./repo/",source="git-data",state="SUCCESS"} 1'
+stdout 'ocp_git_sync_duration_seconds_count{repo="./repo/",source="git-data"} 1'
+stdout 'ocp_git_sync_duration_seconds_sum.*'
+stdout 'ocp_git_sync_duration_seconds_bucket.*'
+stdout 'ocp_bundle_build_duration_seconds_count{bundle="hello-world"} 1'
+stdout 'ocp_bundle_build_duration_seconds_sum.*'
+stdout 'ocp_bundle_build_duration_seconds_bucket.*'
+stdout 'ocp_bundle_build_count_total{bundle="hello-world",state="SUCCESS"} 1'
+
+kill opactl
+
+-- repo/unrelated.yaml --
+ignore: me
+-- repo/users/data.json --
+[
+  {
+    "id": "alice"
+  },
+  {
+    "id": "bob"
+  }
+]
+-- config.d/bundle.yml --
+bundles:
+  hello-world:
+    object_storage:
+      filesystem:
+        path: bundles/hello-world/bundle.tar.gz
+    requirements:
+    - source: git-data
+sources:
+  git-data:
+    git:
+      repo: ./repo/
+      reference: main
+      excluded_files:
+      - unrelated.yaml

--- a/internal/gitsync/gitsync.go
+++ b/internal/gitsync/gitsync.go
@@ -325,7 +325,3 @@ func (a *basicAuth) SetAuth(r *gohttp.Request) {
 		}
 	}
 }
-
-func (s *Synchronizer) updatePostSyncMetrics(startTime time.Time) {
-	metrics.GitSyncDuration.WithLabelValues(s.sourceName, s.config.Repo).Observe(float64(time.Since(startTime).Seconds()))
-}

--- a/internal/gitsync/gitsync.go
+++ b/internal/gitsync/gitsync.go
@@ -62,13 +62,13 @@ func New(path string, config config.Git, sourceName string) *Synchronizer {
 // on disk, clone it. If it does exist, pull the latest changes and rebase the local branch onto the remote branch.
 func (s *Synchronizer) Execute(ctx context.Context) error {
 	startTime := time.Now()
-	defer s.updatePostSyncMetrics(startTime)
 
 	if err := s.execute(ctx); err != nil {
-		metrics.GitSyncCount.WithLabelValues(s.sourceName, s.config.Repo, "failed").Inc()
+		metrics.GitSyncFailed(s.sourceName, s.config.Repo)
 		return fmt.Errorf("source %q: git synchronizer: %v: %w", s.sourceName, s.config.Repo, err)
 	}
-	metrics.GitSyncCount.WithLabelValues(s.sourceName, s.config.Repo, "success").Inc()
+
+	metrics.GitSyncSucceeded(s.sourceName, s.config.Repo, startTime)
 	return nil
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,11 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func Handler() http.Handler {
+	return promhttp.Handler()
+}

--- a/internal/metrics/metrics_gitsync.go
+++ b/internal/metrics/metrics_gitsync.go
@@ -1,0 +1,48 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	GitSyncFailed = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ocp_git_sync_failed_total",
+			Help: "Total number of failed Git sync operations",
+		},
+		[]string{"source"},
+	)
+
+	GitSyncCount = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ocp_git_sync_count_total",
+			Help: "Total number of Git sync operations",
+		},
+	)
+
+	GitSyncDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "ocp_git_sync_duration_seconds",
+			Help:    "Git sync duration in seconds",
+			Buckets: []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.5, 2, 5, 10, 30, 60},
+		},
+		[]string{"source", "repo"},
+	)
+
+	LastGitSyncStart = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocp_last_git_sync_start_timestamp",
+			Help: "Unix timestamp of when the last git sync started",
+		},
+		[]string{"source", "repo"},
+	)
+
+	LastGitSyncEnd = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocp_last_git_sync_end_timestamp",
+			Help: "Unix timestamp of when the last git sync ended",
+		},
+		[]string{"source", "repo"},
+	)
+)

--- a/internal/metrics/metrics_gitsync.go
+++ b/internal/metrics/metrics_gitsync.go
@@ -6,19 +6,12 @@ import (
 )
 
 var (
-	GitSyncFailed = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "ocp_git_sync_failed_total",
-			Help: "Total number of failed Git sync operations",
-		},
-		[]string{"source"},
-	)
-
-	GitSyncCount = promauto.NewCounter(
+	GitSyncCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ocp_git_sync_count_total",
-			Help: "Total number of Git sync operations",
+			Help: "Number of times a git sync has been performed and its state",
 		},
+		[]string{"source", "repo", "state"},
 	)
 
 	GitSyncDuration = promauto.NewHistogramVec(
@@ -26,22 +19,6 @@ var (
 			Name:    "ocp_git_sync_duration_seconds",
 			Help:    "Git sync duration in seconds",
 			Buckets: []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.5, 2, 5, 10, 30, 60},
-		},
-		[]string{"source", "repo"},
-	)
-
-	LastGitSyncStart = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "ocp_last_git_sync_start_timestamp",
-			Help: "Unix timestamp of when the last git sync started",
-		},
-		[]string{"source", "repo"},
-	)
-
-	LastGitSyncEnd = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "ocp_last_git_sync_end_timestamp",
-			Help: "Unix timestamp of when the last git sync ended",
 		},
 		[]string{"source", "repo"},
 	)

--- a/internal/metrics/metrics_gitsync.go
+++ b/internal/metrics/metrics_gitsync.go
@@ -27,10 +27,10 @@ var (
 )
 
 func GitSyncFailed(source string, repo string) {
-	GitSyncCount.WithLabelValues(source, repo, "failed").Inc()
+	GitSyncCount.WithLabelValues(source, repo, "FAILED").Inc()
 }
 
 func GitSyncSucceeded(source string, repo string, startTime time.Time) {
-	GitSyncCount.WithLabelValues(source, repo, "success").Inc()
+	GitSyncCount.WithLabelValues(source, repo, "SUCCESS").Inc()
 	GitSyncDuration.WithLabelValues(source, repo).Observe(float64(time.Since(startTime).Seconds()))
 }

--- a/internal/metrics/metrics_gitsync.go
+++ b/internal/metrics/metrics_gitsync.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -23,3 +25,12 @@ var (
 		[]string{"source", "repo"},
 	)
 )
+
+func GitSyncFailed(source string, repo string) {
+	GitSyncCount.WithLabelValues(source, repo, "failed").Inc()
+}
+
+func GitSyncSucceeded(source string, repo string, startTime time.Time) {
+	GitSyncCount.WithLabelValues(source, repo, "success").Inc()
+	GitSyncDuration.WithLabelValues(source, repo).Observe(float64(time.Since(startTime).Seconds()))
+}

--- a/internal/metrics/metrics_worker.go
+++ b/internal/metrics/metrics_worker.go
@@ -1,0 +1,48 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	BundleBuildFailed = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ocp_bundle_build_failed",
+			Help: "Number of times a bundle has failed to build",
+		},
+		[]string{"bundle", "error_type"},
+	)
+
+	BundleBuildCount = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ocp_bundle_build_count",
+			Help: "Total number of times a bundle has been built",
+		},
+	)
+
+	BundleBuildDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "ocp_bundle_build_duration_seconds",
+			Help:    "Bundle build duration in seconds",
+			Buckets: []float64{0.1, 0.2, 0.5, 1, 1.5, 2, 5, 10, 30, 60},
+		},
+		[]string{"bundle"},
+	)
+
+	LastBundleBuildStart = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocp_last_bundle_build_start_timestamp",
+			Help: "Unix timestamp of when the last bundle build started",
+		},
+		[]string{"bundle"},
+	)
+
+	LastBundleBuildEnd = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocp_last_bundle_build_end_timestamp",
+			Help: "Unix timestamp of when the last bundle build ended",
+		},
+		[]string{"bundle"},
+	)
+)

--- a/internal/metrics/metrics_worker.go
+++ b/internal/metrics/metrics_worker.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -23,3 +25,12 @@ var (
 		[]string{"bundle"},
 	)
 )
+
+func BundleBuildFailed(bundle string, state string) {
+	BundleBuildCount.WithLabelValues(bundle, state).Inc()
+}
+
+func BundleBuildSucceeded(bundle string, state string, startTime time.Time) {
+	BundleBuildCount.WithLabelValues(bundle, state).Inc()
+	BundleBuildDuration.WithLabelValues(bundle).Observe(float64(time.Since(startTime).Seconds()))
+}

--- a/internal/metrics/metrics_worker.go
+++ b/internal/metrics/metrics_worker.go
@@ -6,19 +6,12 @@ import (
 )
 
 var (
-	BundleBuildFailed = promauto.NewCounterVec(
+	BundleBuildCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "ocp_bundle_build_failed",
-			Help: "Number of times a bundle has failed to build",
+			Name: "ocp_bundle_build_count_total",
+			Help: "Number of times a bundle build has been performed and its state",
 		},
-		[]string{"bundle", "error_type"},
-	)
-
-	BundleBuildCount = promauto.NewCounter(
-		prometheus.CounterOpts{
-			Name: "ocp_bundle_build_count",
-			Help: "Total number of times a bundle has been built",
-		},
+		[]string{"bundle", "state"},
 	)
 
 	BundleBuildDuration = promauto.NewHistogramVec(
@@ -26,22 +19,6 @@ var (
 			Name:    "ocp_bundle_build_duration_seconds",
 			Help:    "Bundle build duration in seconds",
 			Buckets: []float64{0.1, 0.2, 0.5, 1, 1.5, 2, 5, 10, 30, 60},
-		},
-		[]string{"bundle"},
-	)
-
-	LastBundleBuildStart = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "ocp_last_bundle_build_start_timestamp",
-			Help: "Unix timestamp of when the last bundle build started",
-		},
-		[]string{"bundle"},
-	)
-
-	LastBundleBuildEnd = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "ocp_last_bundle_build_end_timestamp",
-			Help: "Unix timestamp of when the last bundle build ended",
 		},
 		[]string{"bundle"},
 	)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/v1/server/writer"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/styrainc/opa-control-plane/internal/config"
 	"github.com/styrainc/opa-control-plane/internal/database"
@@ -33,6 +34,7 @@ func (s *Server) Init() *Server {
 		s.router = http.NewServeMux()
 	}
 
+	s.router.Handle("GET    /metrics", promhttp.Handler())
 	s.router.HandleFunc("GET    /health", s.health)
 	s.router.HandleFunc("GET    /v1/sources/{source}/data/{path...}", authenticationMiddleware(s.db, s.v1SourcesDataGet))
 	s.router.HandleFunc("POST   /v1/sources/{source}/data/{path...}", authenticationMiddleware(s.db, s.v1SourcesDataPut))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/v1/server/writer"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/styrainc/opa-control-plane/internal/config"
 	"github.com/styrainc/opa-control-plane/internal/database"
+	"github.com/styrainc/opa-control-plane/internal/metrics"
 	"github.com/styrainc/opa-control-plane/internal/server/types"
 )
 
@@ -34,7 +34,7 @@ func (s *Server) Init() *Server {
 		s.router = http.NewServeMux()
 	}
 
-	s.router.Handle("GET    /metrics", promhttp.Handler())
+	s.router.Handle("GET /metrics", metrics.Handler())
 	s.router.HandleFunc("GET    /health", s.health)
 	s.router.HandleFunc("GET    /v1/sources/{source}/data/{path...}", authenticationMiddleware(s.db, s.v1SourcesDataGet))
 	s.router.HandleFunc("POST   /v1/sources/{source}/data/{path...}", authenticationMiddleware(s.db, s.v1SourcesDataPut))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,7 +34,7 @@ func (s *Server) Init() *Server {
 		s.router = http.NewServeMux()
 	}
 
-	s.router.Handle("GET /metrics", metrics.Handler())
+	s.router.Handle("/metrics", metrics.Handler())
 	s.router.HandleFunc("GET    /health", s.health)
 	s.router.HandleFunc("GET    /v1/sources/{source}/data/{path...}", authenticationMiddleware(s.db, s.v1SourcesDataGet))
 	s.router.HandleFunc("POST   /v1/sources/{source}/data/{path...}", authenticationMiddleware(s.db, s.v1SourcesDataPut))


### PR DESCRIPTION
Part of solution to #90 

Not the most experienced Go developer, and also havent gained a deep understanding of the innerworking of OCP, but this is a first try on adding metrics related to git syncs and bundle builds. All comments are appreciated so we can end up with a good solution 👍

Example of output:

```
# HELP go_gc_duration_seconds A summary of the wall-time pause (stop-the-world) duration in garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0.0001709
go_gc_duration_seconds{quantile="0.25"} 0.0003461
go_gc_duration_seconds{quantile="0.5"} 0.0004784
go_gc_duration_seconds{quantile="0.75"} 0.0005837
go_gc_duration_seconds{quantile="1"} 0.0034565
go_gc_duration_seconds_sum 0.0410687
go_gc_duration_seconds_count 78
# HELP go_gc_gogc_percent Heap size target percentage configured by the user, otherwise 100. This value is set by the GOGC environment variable, and the runtime/debug.SetGCPercent function. Sourced from /gc/gogc:percent.
# TYPE go_gc_gogc_percent gauge
go_gc_gogc_percent 100
# HELP go_gc_gomemlimit_bytes Go runtime memory limit configured by the user, otherwise math.MaxInt64. This value is set by the GOMEMLIMIT environment variable, and the runtime/debug.SetMemoryLimit function. Sourced from /gc/gomemlimit:bytes.
# TYPE go_gc_gomemlimit_bytes gauge
go_gc_gomemlimit_bytes 9.223372036854776e+18
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 20
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.24.6"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated in heap and currently in use. Equals to /memory/classes/heap/objects:bytes.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 2.530072e+07
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated in heap until now, even if released already. Equals to /gc/heap/allocs:bytes.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 7.85754928e+08
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table. Equals to /memory/classes/profiling/buckets:bytes.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 2.186202e+06
# HELP go_memstats_frees_total Total number of heap objects frees. Equals to /gc/heap/frees:objects + /gc/heap/tiny/allocs:objects.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 8.958608e+06
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata. Equals to /memory/classes/metadata/other:bytes.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 4.462088e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and currently in use, same as go_memstats_alloc_bytes. Equals to /memory/classes/heap/objects:bytes.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 2.530072e+07
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used. Equals to /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 8.617984e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 3.2407552e+07
# HELP go_memstats_heap_objects Number of currently allocated objects. Equals to /gc/heap/objects:objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 228446
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS. Equals to /memory/classes/heap/released:bytes.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 6.684672e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes + /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 4.1025536e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.7594078475223777e+09
# HELP go_memstats_mallocs_total Total number of heap objects allocated, both live and gc-ed. Semantically a counter version for go_memstats_heap_objects gauge. Equals to /gc/heap/allocs:objects + /gc/heap/tiny/allocs:objects.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 9.187054e+06
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures. Equals to /memory/classes/metadata/mcache/inuse:bytes.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 14496
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system. Equals to /memory/classes/metadata/mcache/inuse:bytes + /memory/classes/metadata/mcache/free:bytes.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 15704
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures. Equals to /memory/classes/metadata/mspan/inuse:bytes.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 560960
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system. Equals to /memory/classes/metadata/mspan/inuse:bytes + /memory/classes/metadata/mspan/free:bytes.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 636480
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place. Equals to /gc/heap/goal:bytes.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 3.3123138e+07
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations. Equals to /memory/classes/other:bytes.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 2.420622e+06
# HELP go_memstats_stack_inuse_bytes Number of bytes obtained from system for stack allocator in non-CGO environments. Equals to /memory/classes/heap/stacks:bytes.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 917504
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator. Equals to /memory/classes/heap/stacks:bytes + /memory/classes/os-stacks:bytes.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 917504
# HELP go_memstats_sys_bytes Number of bytes obtained from system. Equals to /memory/classes/total:byte.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 5.1664136e+07
# HELP go_sched_gomaxprocs_threads The current runtime.GOMAXPROCS setting, or the number of operating system threads that can execute user-level Go code simultaneously. Sourced from /sched/gomaxprocs:threads.
# TYPE go_sched_gomaxprocs_threads gauge
go_sched_gomaxprocs_threads 12
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 16
# HELP ocp_bundle_build_count_total Number of times a bundle build has been performed and its state
# TYPE ocp_bundle_build_count_total counter
ocp_bundle_build_count_total{bundle="bundle1",state="SUCCESS"} 1
# HELP ocp_bundle_build_duration_seconds Bundle build duration in seconds
# TYPE ocp_bundle_build_duration_seconds histogram
ocp_bundle_build_duration_seconds_bucket{bundle="bundle1",le="0.1"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="bundle1",le="0.2"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="bundle1",le="0.5"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="bundle1",le="1"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="bundle1",le="1.5"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="bundle1",le="2"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="bundle1",le="5"} 1
ocp_bundle_build_duration_seconds_bucket{bundle="bundle1",le="10"} 1
ocp_bundle_build_duration_seconds_bucket{bundle="bundle1",le="30"} 1
ocp_bundle_build_duration_seconds_bucket{bundle="bundle1",le="60"} 1
ocp_bundle_build_duration_seconds_bucket{bundle="bundle1",le="+Inf"} 1
ocp_bundle_build_duration_seconds_sum{bundle="bundle1"} 3.529491444
ocp_bundle_build_duration_seconds_count{bundle="bundle1"} 1
# HELP ocp_git_sync_count_total Number of times a git sync has been performed and its state
# TYPE ocp_git_sync_count_total counter
ocp_git_sync_count_total{repo="https://github.com/repo1.git",source="source1",state="SUCCESS"} 1
ocp_git_sync_count_total{repo="https://github.com/repo2.git",source="source2",state="SUCCESS"} 1
# HELP ocp_git_sync_duration_seconds Git sync duration in seconds
# TYPE ocp_git_sync_duration_seconds histogram
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="0.1"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="0.2"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="0.3"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="0.4"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="0.5"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="0.6"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="0.7"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="0.8"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="0.9"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="1"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="1.5"} 1
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="2"} 1
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="5"} 1
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="10"} 1
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="30"} 1
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="60"} 1
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo1.git",source="source1",le="+Inf"} 1
ocp_git_sync_duration_seconds_sum{repo="https://github.com/repo1.git",source="source1"} 1.492988019
ocp_git_sync_duration_seconds_count{repo="https://github.com/repo1.git",source="source1"} 1
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="0.1"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="0.2"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="0.3"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="0.4"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="0.5"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="0.6"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="0.7"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="0.8"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="0.9"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="1"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="1.5"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="2"} 1
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="5"} 1
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="10"} 1
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="30"} 1
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="60"} 1
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/repo2.git",source="source2",le="+Inf"} 1
ocp_git_sync_duration_seconds_sum{repo="https://github.com/repo2.git",source="source2"} 1.758345522
ocp_git_sync_duration_seconds_count{repo="https://github.com/repo2.git",source="source2"} 1
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 5.05
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP process_network_receive_bytes_total Number of bytes received by the process over the network.
# TYPE process_network_receive_bytes_total counter
process_network_receive_bytes_total 2.72391352e+08
# HELP process_network_transmit_bytes_total Number of bytes sent by the process over the network.
# TYPE process_network_transmit_bytes_total counter
process_network_transmit_bytes_total 2.38043678e+08
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 14
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 9.869312e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.75940784031e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 2.4064e+09
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 1
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```