### PR TITLE
cmd/run: run migrations if using sqlite

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -59,14 +59,14 @@ func init() {
 				log.Fatalf("configuration error: %v", err)
 			}
 
-			config.SetSQLitePersistentByDefault(params.persistenceDir)
+			sqlite := config.SetSQLitePersistentByDefault(params.persistenceDir)
 
 			svc := service.New().
 				WithPersistenceDir(params.persistenceDir).
 				WithConfig(config).
 				WithBuiltinFS(util.NewEscapeFS(libraries.FS)).
 				WithLogger(log).
-				WithMigrateDB(params.migrateDB)
+				WithMigrateDB(params.migrateDB || sqlite) // always run migrations with sqlite
 
 			// NOTE(sr): We run Init() separately here because we're passing svc.Database() to server below
 			if err := svc.Init(ctx); err != nil {

--- a/e2e/cli/run_basic.txtar
+++ b/e2e/cli/run_basic.txtar
@@ -1,0 +1,52 @@
+exec $OPACTL run --config config.d/bundle.yml --data-dir tmp &opactl&
+! stderr .
+! stdout .
+
+exec curl --retry 5 --retry-all-errors http://127.0.0.1:8282/health
+
+kill opactl
+exec ls tmp/sqlite.db # sqlite in persistence dir
+
+exec tar tf bundles/hello-world/bundle.tar.gz
+cmp stdout exp/tarball
+exec tar xf bundles/hello-world/bundle.tar.gz
+cmp data.json exp/data.json
+cmp .manifest exp/.manifest
+
+-- data/common.json --
+{ "common": true }
+-- files/sources/hello-world/prefix/data.json --
+{ "some": "thing" }
+-- files/sources/hello-world/rules/rules.rego --
+package rules
+import rego.v1
+result if input.yay
+-- config.d/bundle.yml --
+bundles:
+  hello-world:
+    object_storage:
+      filesystem:
+        path: bundles/hello-world/bundle.tar.gz
+    requirements:
+    - source: dir-paths
+    - source: global-data
+    - source: builtin-entz
+sources:
+  dir-paths:
+    directory: files/sources/hello-world
+    paths:
+    - prefix/data.json
+    - rules/rules.rego
+  builtin-entz:
+    styra.entitlements.v1: entitlements-v1/completions/completions/completions.rego
+  global-data:
+    paths:
+    - data/common.json
+-- exp/tarball --
+/data.json
+/dir-paths/rules/rules.rego
+/.manifest
+-- exp/data.json --
+{"data":{"common":true},"prefix":{"some":"thing"}}
+-- exp/.manifest --
+{"revision":"","roots":["prefix","rules","data"],"rego_version":0}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,7 @@ type Root struct {
 // database stored in the given persistence directory if no other database configuration
 // exists. This is used for the 'run' command to change its default behavior from other
 // commands.
-func (r *Root) SetSQLitePersistentByDefault(persistenceDir string) {
+func (r *Root) SetSQLitePersistentByDefault(persistenceDir string) bool {
 	if r.Database == nil {
 		r.Database = &Database{}
 	}
@@ -59,7 +59,9 @@ func (r *Root) SetSQLitePersistentByDefault(persistenceDir string) {
 		r.Database.SQL.Driver == "sqlite3" || r.Database.SQL.Driver == "sqlite") && r.Database.SQL.DSN == "" {
 		r.Database.SQL.Driver = "sqlite3"
 		r.Database.SQL.DSN = filepath.Join(persistenceDir, "sqlite.db")
+		return true
 	}
+	return false
 }
 
 // UnmarshalYAML implements the yaml.Marshaler interface for the Root struct. This

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -245,6 +245,7 @@ func (s *Service) launchWorkers(ctx context.Context) {
 		s.log.Errorf("error listing bundles: %s", err.Error())
 		return
 	}
+	s.log.Debugf("launchWorkers for %d bundles", len(bundles))
 
 	sourceDefs, _, err := s.database.ListSources(ctx, internalPrincipal, database.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
Without this, some test setups would suddenly fail with

"msg":"initialize service: failed to insert principal: SQL logic error: no such table: principals (1)"

Now, the logic here is the same as with `opactl build`.