### PR TITLE
cmd/migrate: only iterate over stacks matched by systems

### DIFF
--- a/cmd/internal/das/das.go
+++ b/cmd/internal/das/das.go
@@ -22,6 +22,7 @@ type V1System struct {
 	BundleRegistry struct {
 		ManualDeployment bool `json:"manual_deployment"`
 	} `json:"bundle_registry"`
+	MatchingStacks []string `json:"matching_stacks"`
 }
 
 func (v1 *V1System) SanitizedName() string {

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -2226,10 +2226,19 @@ func fetchDASState(silent bool, c *das.Client, opts dasFetchOptions) (*dasState,
 		return nil, err
 	}
 
-	var stacks []*das.V1Stack
-	err = resp.Decode(&stacks)
+	var s []*das.V1Stack
+	err = resp.Decode(&s)
 	if err != nil {
 		return nil, err
+	}
+
+	var stacks []*das.V1Stack
+	for _, stack := range s {
+		for _, sys := range systems {
+			if slices.Contains(sys.MatchingStacks, stack.Id) {
+				stacks = append(stacks, stack)
+			}
+		}
 	}
 
 	bar.AddMax(len(stacks))


### PR DESCRIPTION
Adapt the migrate command to only consider stacks that are actually referenced as matching stacks by systems.

Skip stacks that are not referenced by systems to speed up the migration. In larger Styra DAS setups with lots of stacks this speeds up the migration considerably - especially when only migrating a single system (CLI flag --system-id).