### PR TITLE
config,server: add configuration option to set api prefix for server

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -73,7 +73,7 @@ func init() {
 			}
 
 			go func() {
-				if err := server.New().WithDatabase(svc.Database()).WithReadiness(svc.Ready).Init().ListenAndServe(params.addr); err != nil {
+				if err := server.New().WithDatabase(svc.Database()).WithReadiness(svc.Ready).WithConfig(config.Service).Init().ListenAndServe(params.addr); err != nil {
 					log.Fatalf("failed to start server: %v", err)
 				}
 			}()

--- a/e2e/cli/run_api_prefix.txtar
+++ b/e2e/cli/run_api_prefix.txtar
@@ -1,0 +1,31 @@
+exec $OPACTL run --addr 127.0.0.1:8284 --config config.d/bundle.yml --data-dir tmp-api-prefix &opactl&
+! stderr .
+! stdout .
+
+exec curl --retry 5 --retry-all-errors http://127.0.0.1:8284/my/api/health
+stdout '\{\}'
+
+exec curl --retry 5 --retry-all-errors -H 'Authorization: Bearer admin-token' http://127.0.0.1:8284/my/api/v1/bundles
+stdout '\{\}'
+
+exec curl --retry 5 --retry-all-errors -H 'Authorization: Bearer admin-token' http://127.0.0.1:8284/my/api/v1/sources
+stdout '\{\}'
+
+exec curl --retry 5 --retry-all-errors -H 'Authorization: Bearer admin-token' http://127.0.0.1:8284/my/api/v1/stacks
+
+exec curl --retry 5 --retry-all-errors http://127.0.0.1:8284/my/api/metrics
+stdout '/my/api'
+
+! exec curl -f --retry 1 --retry-all-errors http://127.0.0.1:8284/health
+! exec curl -f --retry 1 --retry-all-errors -H 'Authorization: Bearer admin-token' http://127.0.0.1:8284/v1/bundles
+
+kill opactl
+
+-- config.d/bundle.yml --
+tokens:
+  admin:
+    api_key: admin-token
+    scopes:
+    - role: administrator
+service:
+  api_prefix: /my/api

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type Root struct {
 	Secrets  map[string]*Secret `json:"secrets,omitempty" yaml:"secrets,omitempty"` // Schema validation overrides Secret to object type.
 	Tokens   map[string]*Token  `json:"tokens,omitempty" yaml:"tokens,omitempty"`
 	Database *Database          `json:"database,omitempty" yaml:"database,omitempty"`
+	Service  *Service           `json:"service,omitempty" yaml:"service,omitempty"`
 }
 
 // SetSQLitePersistentByDefault sets the database configuration to use a SQLite
@@ -984,6 +985,12 @@ type AmazonRDS struct {
 	// root CA certificates are used. For RDS, you can download the appropriate bundle for your region
 	// from here: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions
 	RootCertificates string `json:"root_certificates,omitempty" yaml:"root_certificates,omitempty"`
+}
+
+type Service struct {
+	// ApiPrefix prefixes all endpoints (including health and metrics) with its value. It is important to start with `/` and not end with `/`.
+	// For example `/my/path` will make health endpoint be accessible under `/my/path/health`
+	ApiPrefix string `json:"api_prefix,omitempty" yaml:"api_prefix,omitempty" pattern:"^/([^/].*[^/])?$"`
 }
 
 func setEqual[K comparable, V any](a, b []V, key func(V) K, eq func(a, b V) bool) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -338,3 +338,74 @@ func TestSetSQLitePersistentByDefault(t *testing.T) {
 		})
 	}
 }
+
+func TestServiceApiPrefixValidation(t *testing.T) {
+	tests := []struct {
+		note      string
+		config    string
+		shouldErr bool
+		errMsg    string
+	}{
+		{
+			note: "valid api_prefix with leading slash",
+			config: `{
+		service: {
+			api_prefix: "/api/v1"
+		}
+	}`,
+			shouldErr: false,
+		},
+		{
+			note: "valid api_prefix with just slash",
+			config: `{
+		service: {
+			api_prefix: "/"
+		}
+	}`,
+			shouldErr: false,
+		},
+		{
+			note: "invalid api_prefix without leading slash",
+			config: `{
+		service: {
+			api_prefix: "api/v1"
+		}
+	}`,
+			shouldErr: true,
+			errMsg:    "does not match pattern",
+		},
+		{
+			note: "valid when api_prefix omitted completely",
+			config: `{
+		service: {}
+	}`,
+			shouldErr: false,
+		},
+		{
+			note: "invalid api_prefix with trailing slash",
+			config: `{
+		service: {
+			api_prefix: "/api/v1/"
+		}
+	}`,
+			shouldErr: true,
+			errMsg:    "does not match pattern",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.note, func(t *testing.T) {
+			_, err := config.Parse(bytes.NewReader([]byte(tt.config)))
+			if tt.shouldErr {
+				if err == nil {
+					t.Fatalf("expected validation error but got none")
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Fatalf("expected error containing %q but got: %v", tt.errMsg, err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Sometimes there is a need to listen on different path than root. Corporate policy or widely applied convention. Added configuration option will allow for modifying the prefix via config entry.
Eg:
```yaml
service:
    api_prefix: /my/prefix
```
will change path for example for health endpoint to `/my/prefix/health`.
This applies to all endpoints.