### PR TITLE
config: add externalized "config/schema.json", validate earlier

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,3 +12,8 @@ jobs:
       - name: Golang Style and Lint Check
         run: make check
         timeout-minutes: 30
+      - name: verify config/schema.json is up to date
+        run: |
+          make generate
+          git diff --exit-code
+

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ all: build test
 
 .PHONY: generate
 generate:
-	$(GO) generate
+	$(GO) generate ./...
 
 .PHONY: build
 build: go-build

--- a/build/gen-config-schema.go
+++ b/build/gen-config-schema.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/open-policy-agent/opa-control-plane/internal/config"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("usage: %s path/to/schema.json", os.Args[0])
+	}
+	bs, err := config.ReflectSchema()
+	if err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(os.Args[1], bs, 0644); err != nil {
+		panic(err)
+	}
+}

--- a/config/schema.go
+++ b/config/schema.go
@@ -1,0 +1,14 @@
+//go:generate go run ../build/gen-config-schema.go schema.json
+
+package config
+
+import (
+	_ "embed"
+)
+
+//go:embed "schema.json"
+var schema []byte
+
+func Schema() []byte {
+	return schema
+}

--- a/config/schema.json
+++ b/config/schema.json
@@ -1,0 +1,428 @@
+{
+  "definitions": {
+    "ConfigAmazonRDS": {
+      "properties": {
+        "credentials": {
+          "type": "string"
+        },
+        "database_name": {
+          "type": "string"
+        },
+        "database_user": {
+          "type": "string"
+        },
+        "driver": {
+          "type": "string"
+        },
+        "dsn": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "root_certificates": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigAmazonS3": {
+      "properties": {
+        "bucket": {
+          "type": "string"
+        },
+        "credentials": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigAzureBlobStorage": {
+      "properties": {
+        "account_url": {
+          "type": "string"
+        },
+        "container": {
+          "type": "string"
+        },
+        "credentials": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigBundle": {
+      "description": "Bundle object",
+      "additionalProperties": false,
+      "properties": {
+        "excluded_files": {
+          "$ref": "#/definitions/ConfigStringSet"
+        },
+        "labels": {
+          "$ref": "#/definitions/ConfigLabels"
+        },
+        "name": {
+          "type": "string"
+        },
+        "object_storage": {
+          "$ref": "#/definitions/ConfigObjectStorage"
+        },
+        "rebuild_interval": {
+          "type": "string"
+        },
+        "requirements": {
+          "$ref": "#/definitions/ConfigRequirements"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigDatabase": {
+      "properties": {
+        "aws_rds": {
+          "$ref": "#/definitions/ConfigAmazonRDS"
+        },
+        "sql": {
+          "$ref": "#/definitions/ConfigSQLDatabase"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigDatasource": {
+      "properties": {
+        "config": {
+          "additionalProperties": {},
+          "type": "object"
+        },
+        "credentials": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "transform_query": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigDatasources": {
+      "items": {
+        "$ref": "#/definitions/ConfigDatasource"
+      },
+      "type": "array"
+    },
+    "ConfigFileSystemStorage": {
+      "properties": {
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigFiles": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "ConfigGCPCloudStorage": {
+      "properties": {
+        "bucket": {
+          "type": "string"
+        },
+        "credentials": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "project": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigGit": {
+      "properties": {
+        "commit": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "credentials": {
+          "type": "string"
+        },
+        "excluded_files": {
+          "$ref": "#/definitions/ConfigStringSet"
+        },
+        "included_files": {
+          "$ref": "#/definitions/ConfigStringSet"
+        },
+        "path": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "reference": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "repo": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigGitRequirement": {
+      "properties": {
+        "commit": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ConfigLabels": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "ConfigMetadata": {
+      "properties": {
+        "exported_at": {
+          "type": "string"
+        },
+        "exported_from": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigObjectStorage": {
+      "properties": {
+        "aws": {
+          "$ref": "#/definitions/ConfigAmazonS3"
+        },
+        "azure": {
+          "$ref": "#/definitions/ConfigAzureBlobStorage"
+        },
+        "filesystem": {
+          "$ref": "#/definitions/ConfigFileSystemStorage"
+        },
+        "gcp": {
+          "$ref": "#/definitions/ConfigGCPCloudStorage"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigRequirement": {
+      "properties": {
+        "git": {
+          "$ref": "#/definitions/ConfigGitRequirement"
+        },
+        "path": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "source": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ConfigRequirements": {
+      "items": {
+        "$ref": "#/definitions/ConfigRequirement"
+      },
+      "type": "array"
+    },
+    "ConfigSQLDatabase": {
+      "type": "object"
+    },
+    "ConfigScope": {
+      "properties": {
+        "role": {
+          "enum": [
+            "administrator",
+            "viewer",
+            "owner",
+            "stack_owner"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigSecret": {
+      "type": "object"
+    },
+    "ConfigSelector": {
+      "additionalProperties": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "type": "object"
+    },
+    "ConfigService": {
+      "properties": {
+        "api_prefix": {
+          "pattern": "^/([^/].*[^/])?$",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigSource": {
+      "properties": {
+        "builtin": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "datasources": {
+          "$ref": "#/definitions/ConfigDatasources"
+        },
+        "directory": {
+          "type": "string"
+        },
+        "files": {
+          "$ref": "#/definitions/ConfigFiles"
+        },
+        "git": {
+          "$ref": "#/definitions/ConfigGit"
+        },
+        "name": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/definitions/ConfigStringSet"
+        },
+        "requirements": {
+          "$ref": "#/definitions/ConfigRequirements"
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "ConfigStack": {
+      "properties": {
+        "exclude_selector": {
+          "$ref": "#/definitions/ConfigSelector"
+        },
+        "name": {
+          "type": "string"
+        },
+        "requirements": {
+          "$ref": "#/definitions/ConfigRequirements"
+        },
+        "selector": {
+          "$ref": "#/definitions/ConfigSelector"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigStringSet": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "ConfigToken": {
+      "properties": {
+        "api_key": {
+          "type": "string"
+        },
+        "scopes": {
+          "items": {
+            "$ref": "#/definitions/ConfigScope"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    }
+  },
+  "properties": {
+    "bundles": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ConfigBundle"
+      },
+      "type": "object"
+    },
+    "database": {
+      "$ref": "#/definitions/ConfigDatabase"
+    },
+    "metadata": {
+      "$ref": "#/definitions/ConfigMetadata"
+    },
+    "secrets": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ConfigSecret"
+      },
+      "type": "object"
+    },
+    "service": {
+      "$ref": "#/definitions/ConfigService"
+    },
+    "sources": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ConfigSource"
+      },
+      "type": "object"
+    },
+    "stacks": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ConfigStack"
+      },
+      "type": "object"
+    },
+    "tokens": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ConfigToken"
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/e2e/cli/db_migrate.txtar
+++ b/e2e/cli/db_migrate.txtar
@@ -22,7 +22,7 @@ bundles:
     object_storage:
       filesystem:
         path: bundles/a/bundle.tar.gz
-    requirements:
+    requirements: []
 -- config.d/local_db.yml --
 database:
   sql:
@@ -33,5 +33,4 @@ bundles:
     object_storage:
       filesystem:
         path: bundles/a/bundle.tar.gz
-    requirements:
-
+    requirements: []

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -424,6 +424,47 @@ stacks:
   empty-stack:
 `)
 	_, _ = config.Parse(cfg)
+	// it has not panicked
+}
+
+func TestValidateYAML(t *testing.T) {
+	{ // This is OK, empty sources can be used for PUT /sources/<name>/data/<path> updates
+		cfg := []byte(`
+sources:
+  empty-source:
+`)
+		_, err := config.Parse(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	{ // These cannot be empty: It won't panic, but it won't pass validation either
+		cfg := []byte(`
+tokens:
+  empty-token:
+bundles:
+  empty-bundle:
+secrets:
+  empty-secret:
+stacks:
+  empty-stack:
+`)
+		_, err := config.Parse(cfg)
+		exp := []string{
+			`- at '/stacks/empty-stack': got null, want object`,
+			`- at '/tokens/empty-token': got null, want object`,
+			`- at '/bundles/empty-bundle': got null, want object`,
+			`- at '/secrets/empty-secret': got null, want object`,
+		}
+		for _, line := range exp {
+			if !strings.Contains(err.Error(), line) {
+				t.Errorf("expected error with line %q", line)
+			}
+		}
+		if t.Failed() && err != nil {
+			t.Logf("error: %q", err.Error())
+		}
+	}
 }
 
 func TestRequirementsEqual(t *testing.T) {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1,34 +1,24 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
-	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	schemareflector "github.com/swaggest/jsonschema-go"
+
+	ext_config "github.com/open-policy-agent/opa-control-plane/config"
 )
 
 var rootSchema *jsonschema.Schema
 
 func init() {
-	reflector := schemareflector.Reflector{}
-
-	s, err := reflector.Reflect(Root{})
+	js, err := jsonschema.UnmarshalJSON(bytes.NewReader(ext_config.Schema()))
 	if err != nil {
 		panic(err)
 	}
-
-	data, err := json.MarshalIndent(s, "", "  ")
-	if err != nil {
-		panic(err)
-	}
-
-	js, err := jsonschema.UnmarshalJSON(strings.NewReader(string(data)))
-	if err != nil {
-		panic(err)
-	}
-
 	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft2020)
 	if err := compiler.AddResource("schema.json", js); err != nil {
 		panic(err)
 	}
@@ -39,8 +29,31 @@ func init() {
 	}
 }
 
+func ReflectSchema() ([]byte, error) {
+	reflector := schemareflector.Reflector{}
+
+	s, err := reflector.Reflect(Root{})
+	if err != nil {
+		return nil, err
+	}
+
+	return json.MarshalIndent(s, "", "  ")
+}
+
 func (Duration) PrepareJSONSchema(schema *schemareflector.Schema) error {
 	schema.Type = nil
 	schema.AddType(schemareflector.String)
+	return nil
+}
+
+// We do this so that the following YAML config is considered valid:
+//
+//	sources:
+//	  empty-source:
+//
+// This would be desirable when you want a source to only be there for
+// PUT data updates.
+func (*Source) PrepareJSONSchema(schema *schemareflector.Schema) error {
+	schema.AddType(schemareflector.Null)
 	return nil
 }

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,428 @@
+{
+  "definitions": {
+    "ConfigAmazonRDS": {
+      "properties": {
+        "credentials": {
+          "type": "string"
+        },
+        "database_name": {
+          "type": "string"
+        },
+        "database_user": {
+          "type": "string"
+        },
+        "driver": {
+          "type": "string"
+        },
+        "dsn": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "root_certificates": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigAmazonS3": {
+      "properties": {
+        "bucket": {
+          "type": "string"
+        },
+        "credentials": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigAzureBlobStorage": {
+      "properties": {
+        "account_url": {
+          "type": "string"
+        },
+        "container": {
+          "type": "string"
+        },
+        "credentials": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigBundle": {
+      "description": "Bundle object",
+      "additionalProperties": false,
+      "properties": {
+        "excluded_files": {
+          "$ref": "#/definitions/ConfigStringSet"
+        },
+        "labels": {
+          "$ref": "#/definitions/ConfigLabels"
+        },
+        "name": {
+          "type": "string"
+        },
+        "object_storage": {
+          "$ref": "#/definitions/ConfigObjectStorage"
+        },
+        "rebuild_interval": {
+          "type": "string"
+        },
+        "requirements": {
+          "$ref": "#/definitions/ConfigRequirements"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigDatabase": {
+      "properties": {
+        "aws_rds": {
+          "$ref": "#/definitions/ConfigAmazonRDS"
+        },
+        "sql": {
+          "$ref": "#/definitions/ConfigSQLDatabase"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigDatasource": {
+      "properties": {
+        "config": {
+          "additionalProperties": {},
+          "type": "object"
+        },
+        "credentials": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "transform_query": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigDatasources": {
+      "items": {
+        "$ref": "#/definitions/ConfigDatasource"
+      },
+      "type": "array"
+    },
+    "ConfigFileSystemStorage": {
+      "properties": {
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigFiles": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "ConfigGCPCloudStorage": {
+      "properties": {
+        "bucket": {
+          "type": "string"
+        },
+        "credentials": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "project": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigGit": {
+      "properties": {
+        "commit": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "credentials": {
+          "type": "string"
+        },
+        "excluded_files": {
+          "$ref": "#/definitions/ConfigStringSet"
+        },
+        "included_files": {
+          "$ref": "#/definitions/ConfigStringSet"
+        },
+        "path": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "reference": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "repo": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigGitRequirement": {
+      "properties": {
+        "commit": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ConfigLabels": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "ConfigMetadata": {
+      "properties": {
+        "exported_at": {
+          "type": "string"
+        },
+        "exported_from": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigObjectStorage": {
+      "properties": {
+        "aws": {
+          "$ref": "#/definitions/ConfigAmazonS3"
+        },
+        "azure": {
+          "$ref": "#/definitions/ConfigAzureBlobStorage"
+        },
+        "filesystem": {
+          "$ref": "#/definitions/ConfigFileSystemStorage"
+        },
+        "gcp": {
+          "$ref": "#/definitions/ConfigGCPCloudStorage"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigRequirement": {
+      "properties": {
+        "git": {
+          "$ref": "#/definitions/ConfigGitRequirement"
+        },
+        "path": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "source": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ConfigRequirements": {
+      "items": {
+        "$ref": "#/definitions/ConfigRequirement"
+      },
+      "type": "array"
+    },
+    "ConfigSQLDatabase": {
+      "type": "object"
+    },
+    "ConfigScope": {
+      "properties": {
+        "role": {
+          "enum": [
+            "administrator",
+            "viewer",
+            "owner",
+            "stack_owner"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigSecret": {
+      "type": "object"
+    },
+    "ConfigSelector": {
+      "additionalProperties": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "type": "object"
+    },
+    "ConfigService": {
+      "properties": {
+        "api_prefix": {
+          "pattern": "^/([^/].*[^/])?$",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigSource": {
+      "properties": {
+        "builtin": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "datasources": {
+          "$ref": "#/definitions/ConfigDatasources"
+        },
+        "directory": {
+          "type": "string"
+        },
+        "files": {
+          "$ref": "#/definitions/ConfigFiles"
+        },
+        "git": {
+          "$ref": "#/definitions/ConfigGit"
+        },
+        "name": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/definitions/ConfigStringSet"
+        },
+        "requirements": {
+          "$ref": "#/definitions/ConfigRequirements"
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "ConfigStack": {
+      "properties": {
+        "exclude_selector": {
+          "$ref": "#/definitions/ConfigSelector"
+        },
+        "name": {
+          "type": "string"
+        },
+        "requirements": {
+          "$ref": "#/definitions/ConfigRequirements"
+        },
+        "selector": {
+          "$ref": "#/definitions/ConfigSelector"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigStringSet": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "ConfigToken": {
+      "properties": {
+        "api_key": {
+          "type": "string"
+        },
+        "scopes": {
+          "items": {
+            "$ref": "#/definitions/ConfigScope"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    }
+  },
+  "properties": {
+    "bundles": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ConfigBundle"
+      },
+      "type": "object"
+    },
+    "database": {
+      "$ref": "#/definitions/ConfigDatabase"
+    },
+    "metadata": {
+      "$ref": "#/definitions/ConfigMetadata"
+    },
+    "secrets": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ConfigSecret"
+      },
+      "type": "object"
+    },
+    "service": {
+      "$ref": "#/definitions/ConfigService"
+    },
+    "sources": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ConfigSource"
+      },
+      "type": "object"
+    },
+    "stacks": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ConfigStack"
+      },
+      "type": "object"
+    },
+    "tokens": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ConfigToken"
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Now, we'll catch unknown keys. We had to add some frills to make it work with null where objects are required.

Fixes #179 

Here's a screenshot from VSCode after having added this line as the first comment of the yaml file:

```yaml
# yaml-language-server: $schema=https://github.com/open-policy-agent/opa-control-plane/raw/ae78a99fc1bd1b6eb31fd4dfe6e9f26d9a9aabea/schema.json
```

<img width="764" height="200" alt="image" src="https://github.com/user-attachments/assets/d71c19b6-94e1-43a4-99e5-a3dcef766b52" />
