### PR TITLE
bundle: auto-mount matching stacks (add opt-out option)

### DIFF
--- a/config/schema.json
+++ b/config/schema.json
@@ -83,6 +83,9 @@
         "object_storage": {
           "$ref": "#/definitions/ConfigObjectStorage"
         },
+        "options": {
+          "$ref": "#/definitions/ConfigOptions"
+        },
         "rebuild_interval": {
           "type": "string"
         },
@@ -245,6 +248,15 @@
         },
         "gcp": {
           "$ref": "#/definitions/ConfigGCPCloudStorage"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigOptions": {
+      "additionalProperties": false,
+      "properties": {
+        "no_default_stack_mount": {
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/e2e/cli/build_stack_automount.txtar
+++ b/e2e/cli/build_stack_automount.txtar
@@ -27,25 +27,25 @@ result if data.prefix.common != "uncommon"
 -- config.d/bundle.yml --
 bundles:
   hello-world:
-    options:
-      no_default_stack_mount: true
     labels:
       env: production
     object_storage:
       filesystem:
         path: bundles/hello-world/bundle.tar.gz
-    requirements:
-    - source: global-data
-      prefix: data.bundle.req
 stacks:
-  stack-with-mount:
+  without-mount:
     selector:
       env:
       - production
     requirements:
     - source: global-data
-      path: data.common
-      prefix: data.stack.req.new
+  with-mount:
+    selector:
+      env:
+      - production
+    requirements:
+    - source: global-data
+      prefix: global
 sources:
   global-data:
     directory: data/
@@ -63,18 +63,18 @@ sources:
 /global-data/rules.rego
 /.manifest
 -- exp/data.json --
-{"bundle":{"req":{"common":{"foo":{"foo":true}}}},"stack":{"req":{"new":{"foo":{"foo":true}}}}}
+{"stacks":{"with-mount":{"global":{"common":{"foo":{"foo":true}}}},"without-mount":{"common":{"foo":{"foo":true}}}}}
 -- exp/.manifest --
-{"revision":"","roots":["bundle/req/common/rules","bundle/req/common/foo","stack/req/new/rules","stack/req/new/foo"],"rego_version":0}
+{"revision":"","roots":["stacks/with-mount/global/common/rules","stacks/with-mount/global/common/foo","stacks/without-mount/common/rules","stacks/without-mount/common/foo"],"rego_version":0}
 -- exp/global-data/rules.rego --
-package bundle.req.common.rules
+package stacks["with-mount"].global.common.rules
 
 import rego.v1
 
-result if data.bundle.req.foo.common != "uncommon"
+result if data.stacks["with-mount"].global.foo.common != "uncommon"
 -- exp/global-data1/rules.rego --
-package stack.req.new.rules
+package stacks["without-mount"].common.rules
 
 import rego.v1
 
-result if data.foo.common != "uncommon"
+result if data.stacks["without-mount"].foo.common != "uncommon"

--- a/e2e/cli/build_stack_example.txtar
+++ b/e2e/cli/build_stack_example.txtar
@@ -59,7 +59,6 @@ stacks:
       - production
     requirements:
     - source: stack1src
-      prefix: data.stacks.stack1
 sources:
   entrypoint:
     directory: entry/

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log"
 	"maps"
 	"os"
 	"path/filepath"
@@ -540,6 +541,7 @@ func extractAndTransformRego(fsys fs.FS, mnts []mount) (fs.FS, error) {
 		maps.DeleteFunc(modules, func(k string, mod *ast.Module) bool {
 			return !mod.Package.Path.HasPrefix(ast.MustParseRef(from))
 		})
+		log.Println("replacements", replacements)
 
 		res, err := refactor.New().Move(refactor.MoveQuery{
 			Modules:       modules,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -242,6 +242,16 @@ func Validate(data []byte) error {
 	return rootSchema.Validate(config)
 }
 
+type Options struct {
+	NoDefaultStackMount bool `json:"no_default_stack_mount"`
+
+	_ struct{} `additionalProperties:"false"`
+}
+
+func (o Options) Empty() bool {
+	return o == Options{}
+}
+
 // Bundle defines the configuration for an OPA Control Plane Bundle.
 type Bundle struct {
 	Name          string        `json:"name"`
@@ -250,6 +260,7 @@ type Bundle struct {
 	Requirements  Requirements  `json:"requirements,omitempty"`
 	ExcludedFiles StringSet     `json:"excluded_files,omitempty"`
 	Interval      Duration      `json:"rebuild_interval,omitzero"`
+	Options       Options       `json:"options,omitzero"`
 
 	_ struct{} `additionalProperties:"false"`
 }

--- a/internal/migrations/initial.go
+++ b/internal/migrations/initial.go
@@ -15,8 +15,24 @@ func Migrations(dialect string) (fs.FS, error) {
 		initialSchemaFS(dialect),
 		addMounts(dialect),
 		addBundleInterval(dialect),
+		addBundleOptions(dialect),
 	), nil
 }
+
+func addBundleOptions(dialect string) fs.FS {
+	var stmt string
+	switch dialect {
+	case "sqlite", "postgresql":
+		stmt = `ALTER TABLE bundles ADD options TEXT`
+	case "mysql":
+		stmt = `ALTER TABLE bundles ADD options VARCHAR(255)`
+	}
+
+	return ocp_fs.MapFS(map[string]string{
+		"018_add_bundles_options.up.sql": stmt,
+	})
+}
+
 func addBundleInterval(dialect string) fs.FS {
 	var stmt string
 	switch dialect {

--- a/internal/service/testdata/test-config-with-stacks-0040.yaml
+++ b/internal/service/testdata/test-config-with-stacks-0040.yaml
@@ -4,6 +4,9 @@ cases:
         {
           bundles: {
             TestSystem: {
+              options: {
+                no_default_stack_mount: true,
+              },
               labels: {
                 app: payments,
                 env: production


### PR DESCRIPTION
When a stack matches now, it'll be injected with a prefix of

    data.stacks.<stack_name>

You can opt out of this behaviour by providing bundle options:

```yaml
bundles:
  hello-world:
    options:
      no_default_stack_mount: true
```

Existing `prefix` settings on the stack's requirements are respected, so

```yaml
stacks:
  stack1:
    selector: ...
    requirements:
    - source: lib1
      prefix: imported_lib1
```

will cause lib1 to be mounted on `data.stacks.stack1.imported_lib1`.