### PR TITLE
requirements: allow per-source automount override

### DIFF
--- a/config/schema.json
+++ b/config/schema.json
@@ -264,6 +264,12 @@
     "ConfigRequirement": {
       "additionalProperties": false,
       "properties": {
+        "automount": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
         "git": {
           "$ref": "#/definitions/ConfigGitRequirement"
         },

--- a/e2e/cli/build_stack_docs_conflict_resolution.txtar
+++ b/e2e/cli/build_stack_docs_conflict_resolution.txtar
@@ -65,8 +65,6 @@ bundles:
     object_storage:
       filesystem:
         path: bundles/petshop-svc/bundle.tar.gz
-    options:
-      no_default_stack_mount: true
   notifications-svc:
     labels:
       environment: prod
@@ -75,14 +73,13 @@ bundles:
     object_storage:
       filesystem:
         path: bundles/notifications-svc/bundle.tar.gz
-    options:
-      no_default_stack_mount: true
 stacks:
   globalsecurity:
     selector:
       environment: [prod]
     requirements:
     - source: main
+      automount: false # want predictable entrypoint
     - source: globalsecurity
 sources:
   notifications-svc:
@@ -104,7 +101,7 @@ sources:
 /notifications-svc/rules.rego
 /.manifest
 -- exp/notifications-svc/.manifest --
-{"revision":"","roots":["service","globalsecurity","main"],"rego_version":0}
+{"revision":"","roots":["service","stacks/globalsecurity/globalsecurity","main"],"rego_version":0}
 -- exp/petshop-svc/tarball --
 /data.json
 /globalsecurity/rules.rego
@@ -112,4 +109,4 @@ sources:
 /petshop-svc/rules.rego
 /.manifest
 -- exp/petshop-svc/.manifest --
-{"revision":"","roots":["service","globalsecurity","main"],"rego_version":0}
+{"revision":"","roots":["service","stacks/globalsecurity/globalsecurity","main"],"rego_version":0}

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -122,6 +122,8 @@ func TestDatabase(t *testing.T) {
 			data2 := map[string]any{"key": "value2"}
 			dur, _ := time.ParseDuration("1h20m")
 
+			f := false
+
 			root := config.Root{
 				Tokens: map[string]*config.Token{
 					"api-token": {
@@ -143,7 +145,12 @@ func TestDatabase(t *testing.T) {
 							},
 						},
 						Requirements: config.Requirements{
-							config.Requirement{Source: newString("system1"), Path: "data", Prefix: "data.imported"},
+							config.Requirement{
+								Source:    newString("system1"),
+								Path:      "data",
+								Prefix:    "data.imported",
+								AutoMount: &f,
+							},
 						},
 						ExcludedFiles: config.StringSet{"excluded-file1.txt", "excluded-file2.txt"},
 					},
@@ -236,7 +243,7 @@ func TestDatabase(t *testing.T) {
 						Requirements: config.Requirements{
 							config.Requirement{Source: newString("system1")},
 							config.Requirement{Source: newString("system2")},
-							config.Requirement{Source: newString("source-b"), Path: "data", Prefix: "data.b"},
+							config.Requirement{Source: newString("source-b"), Path: "data", Prefix: "data.b", AutoMount: &f},
 						},
 					},
 					"stack2": {
@@ -254,7 +261,7 @@ func TestDatabase(t *testing.T) {
 					"system1": {
 						Name: "system1",
 						Requirements: config.Requirements{
-							config.Requirement{Source: newString("system2")},
+							config.Requirement{Source: newString("system2"), AutoMount: &f},
 							config.Requirement{Source: newString("system3")},
 							config.Requirement{Source: newString("system4")},
 						},

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -38,6 +38,7 @@ func Migrations(dialect string) (fs.FS, error) {
 		addBundleInterval(dialect),
 		addBundleOptions(dialect), // up until #18
 		crossTablesWithIDPKeys(19, dialect),
+		addRequirementsOptions(20, dialect), // adds 3, next is 23.
 	), nil
 }
 

--- a/internal/migrations/migrations_next.go
+++ b/internal/migrations/migrations_next.go
@@ -9,6 +9,26 @@ import (
 	ocp_fs "github.com/open-policy-agent/opa-control-plane/internal/fs"
 )
 
+func addRequirementsOptions(offset int, dialect string) fs.FS {
+	var stmtBundles, stmtSources, stmtStacks string
+	switch dialect {
+	case "sqlite", "postgresql", "cockroachdb":
+		stmtBundles = `ALTER TABLE bundles_requirements ADD options TEXT`
+		stmtSources = `ALTER TABLE sources_requirements ADD options TEXT`
+		stmtStacks = `ALTER TABLE stacks_requirements ADD options TEXT`
+	case "mysql":
+		stmtBundles = `ALTER TABLE bundles_requirements ADD options VARCHAR(255)`
+		stmtSources = `ALTER TABLE sources_requirements ADD options VARCHAR(255)`
+		stmtStacks = `ALTER TABLE stacks_requirements ADD options VARCHAR(255)`
+	}
+
+	return ocp_fs.MapFS(map[string]string{
+		fmt.Sprintf("%03d_bundles_requirements_add_options.up.sql", offset):   stmtBundles,
+		fmt.Sprintf("%03d_sources_requirements_add_options.up.sql", offset+1): stmtSources,
+		fmt.Sprintf("%03d_stacks_requirements_add_options.up.sql", offset+2):  stmtStacks,
+	})
+}
+
 // NOTE(sr): We create new tables to drop constraints. It's hard to predict constraint names
 // across MySQL and Postgres if they have not been set up at creation time.
 // NOTE(sr): We want this to work, or fail, in one step. So this will all be done in a single migration,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -331,7 +331,8 @@ func (s *Service) launchWorkers(ctx context.Context) {
 				if stack.Selector.Matches(b.Labels) && !stack.ExcludeSelector.PtrMatches(b.Labels) {
 					reqs := make([]config.Requirement, len(stack.Requirements))
 					for i, req := range stack.Requirements {
-						if !b.Options.NoDefaultStackMount {
+						if !b.Options.NoDefaultStackMount && // per-bundle opt-out not set
+							(req.AutoMount == nil || *req.AutoMount) { // per-source override is unset or true
 							req.Prefix = addPrefix(defaultStackMountPrefix, stack.Name, req.Prefix)
 						}
 						reqs[i] = req


### PR DESCRIPTION
This new flag allows a per-source opt-out of auto-mounting. Previously, it was only possible to opt-out per bundle (affecting all its sources), for backwards-compatibility.

The new setting can be added wherever a source is _required_: bundles, stacks, sources.

For example, with a bundle, it looks like this:

```yaml
bundles: # "sources:" looks the same
  mysvc:
    requirements:
    - source: mysvc-src
      automount: true # <--- new!
    - source: other-src
```

For stacks:

```yaml
stacks:
  globalsecurity:
    selector:
      environment: [prod]
    requirements:
    - source: main
      automount: true # <--- new!
```

A per-bundle opt-out currently has higher precedence. You cannot opt-out for all sources of a bundle and then opt-in via this setting. If you need this specific behavior, you can provide a `prefix` for the source that is the exception to the bundle-wide opt-out.