### PR TITLE
Fixup for DB bench tests

### DIFF
--- a/internal/database/database_bench_test.go
+++ b/internal/database/database_bench_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	"github.com/open-policy-agent/opa-control-plane/internal/database"
+	"github.com/open-policy-agent/opa-control-plane/internal/migrations"
 )
 
 func BenchmarkPaginationFinalPageLatency(b *testing.B) {
@@ -20,15 +21,14 @@ func BenchmarkPaginationFinalPageLatency(b *testing.B) {
 		b.Run(fmt.Sprint(n), func(b *testing.B) { //nolint:perfsprint
 
 			ctx := context.Background()
-			db := database.New()
-			err := db.InitDB(ctx)
+			db, err := migrations.New().WithMigrate(true).Run(ctx)
 			if err != nil {
-				b.Fatal(err)
+				b.Fatal("db init and migrations: ", err)
 			}
 
 			defer db.CloseDB()
 
-			if err := db.UpsertPrincipal(ctx, database.Principal{Id: "admin", Role: "administrator"}); err != nil {
+			if err := db.UpsertPrincipal(ctx, database.Principal{Id: "admin", Role: "administrator", Tenant: tenant}); err != nil {
 				b.Fatal(err)
 			}
 


### PR DESCRIPTION
Looks like at some point these stopped working. To get things passing it required some extra setup steps to get the schema in place as well as setting the `tenant` on the `principal` getting configured.

With these changes we're back to `make test` (or `make go-bench`) able to succeed.