### PR TITLE
Externalize builder package to pkg/builder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,172 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+OPA Control Plane (OCP) is a centralized management system for Open Policy Agent (OPA) deployments. It provides Git-based policy management, external datasources, highly-available bundle serving, and support for global/hierarchical policies with custom conflict resolution.
+
+The binary is called `opactl` and can be used to build bundles locally or run as a service.
+
+## Common Commands
+
+### Build
+
+```bash
+# Build all bundles defined in config files
+make build
+
+# Or build using the binary directly
+./opactl_darwin_arm64 build -c config.d/
+
+# Build specific bundles only
+./opactl_darwin_arm64 build -c config.d/ --bundle hello-world
+
+# Build with non-interactive mode (CI/CD)
+./opactl_darwin_arm64 build -c config.d/ --noninteractive
+```
+
+### Testing
+
+```bash
+# Run all tests (includes unit tests, benchmarks, library tests, and authz tests)
+make test
+
+# Run only Go unit tests
+make go-test
+
+# Run benchmarks
+make go-bench
+
+# Run library tests
+make library-test
+
+# Run authz tests (OPA policy tests for internal/authz)
+make authz-test
+
+# Run e2e migration tests
+make go-e2e-migrate-test
+```
+
+### Development
+
+```bash
+# Generate code (run before building if generated files changed)
+make generate
+
+# Run linter (requires Docker)
+make check
+
+# Clean build artifacts
+make clean
+```
+
+### Running as a Service
+
+```bash
+# Run the OCP service (starts HTTP API server on localhost:8282)
+./opactl_darwin_arm64 run -c config.d/
+
+# Run on custom address
+./opactl_darwin_arm64 run -c config.d/ --addr 0.0.0.0:8080
+
+# Reset persistence directory (development only)
+./opactl_darwin_arm64 run -c config.d/ --reset-persistence
+```
+
+## Architecture
+
+### Core Components
+
+**Service Layer** (`internal/service/`): The main orchestration layer that manages bundle workers, handles configuration loading, and coordinates the build pipeline. Each bundle gets its own `BundleWorker` that runs independently and continuously rebuilds when source changes are detected.
+
+**Builder** (`internal/builder/`): Compiles OPA bundles from multiple sources. It validates package namespacing (no overlapping packages allowed), merges filesystems from different sources, and uses OPA's native compiler to produce optimized bundles.
+
+**Database** (`internal/database/`): SQL-based storage (SQLite/PostgreSQL/MySQL) for all OCP configuration and state. Stores bundles, sources, stacks, tokens, secrets, and source data. Implements RBAC authorization checks for all operations.
+
+**Synchronizers**: Pull source code and data from external systems before building:
+- **GitSync** (`internal/gitsync/`): Clones/pulls Git repositories with authentication support
+- **HTTPSync** (`internal/httpsync/`): Fetches data from HTTP endpoints
+- **SQLSync** (`internal/sqlsync/`): Retrieves source data from the database
+- **BuiltinSync** (`internal/builtinsync/`): Copies built-in policy libraries from embedded FS
+
+**Storage** (`internal/s3/`): Abstracts cloud object storage for bundle distribution. Supports AWS S3, Google Cloud Storage, Azure Blob Storage, and local filesystem.
+
+**Server** (`internal/server/`): HTTP REST API for managing bundles, sources, and stacks. Authenticated via Bearer tokens. Runs on port 8282 by default when using `opactl run`.
+
+### Configuration System
+
+OCP uses a hierarchical configuration model with three main resource types:
+
+1. **Bundles**: Define what gets built and where it's pushed. Each bundle specifies:
+   - Object storage destination (S3/GCS/Azure/filesystem)
+   - Labels for stack selection
+   - Requirements (sources to include)
+
+2. **Sources**: Define where policies and data come from:
+   - Git repositories (with commit pinning)
+   - HTTP datasources
+   - Embedded files
+   - Built-in libraries
+   - Local directories/files
+
+3. **Stacks**: Inject policies into bundles based on label selectors. Enable organization-wide policies and hierarchical policy composition.
+
+Configuration files are YAML or JSON, can be split across multiple files/directories (loaded in lexical order), and support environment variable substitution for secrets.
+
+### Build Pipeline
+
+1. Service loads configuration from files into database
+2. For each bundle, service creates a BundleWorker
+3. Worker determines applicable stacks based on label selectors
+4. Worker resolves dependency graph of sources (fails on cycles or conflicts)
+5. Synchronizers pull latest source code/data
+6. Builder validates namespace isolation (no overlapping packages)
+7. Builder compiles sources into OPA bundle using merged filesystem
+8. Bundle is pushed to object storage
+9. Process repeats every 15 seconds or on configuration change
+
+### Key Design Patterns
+
+**Worker Pool**: `internal/pool/` provides a goroutine pool (default 10 workers) to build multiple bundles concurrently.
+
+**Namespace Isolation**: Bundles cannot include sources with overlapping package paths (e.g., `x.y` and `x.y.z` conflict). This is validated during the build phase.
+
+**Conflict Resolution**: When multiple policies (from bundle + stacks) produce different decisions, the final policy must implement conflict resolution logic. Common patterns documented in `docs/concepts.md`.
+
+**Persistence Directory Structure**:
+```
+data/
+├── {md5(bundle.Name)}/
+│   └── sources/
+│       └── {source.Name}/
+│           ├── builtin/     # Built-in library files
+│           ├── database/    # Source files from SQL database
+│           ├── datasources/ # HTTP datasource data
+│           └── repo/        # Git repository
+└── sqlite.db  # Default SQLite database (when using 'run' command)
+```
+
+## Libraries
+
+The `libraries/` directory contains built-in policy libraries that can be referenced in source configurations using the `builtin` field:
+- `entitlements-v1`
+- `envoy-v2.0`, `envoy-v2.1`
+- `kong-gateway-v1`
+- `kubernetes-v2`
+- `terraform-v2.0`
+
+Each library has its own Makefile with tests.
+
+## Database Migrations
+
+OCP handles database schema initialization automatically on startup. The migration system is in `internal/database/schema.go`.
+
+## Important Notes
+
+- The `build` command uses in-memory SQLite by default; `run` command uses persistent SQLite by default
+- Configuration merging: last file wins for scalars/lists unless `--merge-conflict-fail` is set
+- Bundle builds are idempotent - running build multiple times with same config produces same result
+- Git sync supports SSH keys, basic auth, GitHub App auth, and token auth
+- Stack selectors support glob patterns for matching label values
+- OPA instances pull bundles directly from object storage, not from OCP server

--- a/internal/service/worker.go
+++ b/internal/service/worker.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/open-policy-agent/opa-control-plane/internal/builder"
+	"github.com/open-policy-agent/opa-control-plane/pkg/builder"
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	"github.com/open-policy-agent/opa-control-plane/internal/logging"
 	"github.com/open-policy-agent/opa-control-plane/internal/metrics"

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -15,8 +15,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"    // nolint:staticcheck
 	"github.com/open-policy-agent/opa/bundle" // nolint:staticcheck
 
-	"github.com/open-policy-agent/opa-control-plane/internal/builder"
-	"github.com/open-policy-agent/opa-control-plane/internal/config"
+	"github.com/open-policy-agent/opa-control-plane/pkg/builder"
 	"github.com/open-policy-agent/opa-control-plane/internal/test/tempfs"
 )
 
@@ -664,9 +663,9 @@ func TestBuilder(t *testing.T) {
 
 				var srcs []*builder.Source
 				for i, src := range tc.sources {
-					var rs []config.Requirement
+					var rs []builder.Requirement
 					for _, r := range src.requirements {
-						rs = append(rs, config.Requirement{
+						rs = append(rs, builder.Requirement{
 							Source: &r.name,
 							Path:   r.path,
 							Prefix: r.prefix,

--- a/pkg/builder/config.go
+++ b/pkg/builder/config.go
@@ -1,0 +1,68 @@
+package builder
+
+// Requirement represents a dependency on another source with optional path mounting.
+// It allows sources to include other sources and remap their package namespaces
+// to avoid conflicts.
+type Requirement struct {
+	// Source is the name of the source to include (required)
+	Source *string
+
+	// Path selects a subtree from the source (e.g., "data.lib" selects only
+	// packages under data.lib). Empty means include everything.
+	Path string
+
+	// Prefix remaps the source to a different namespace (e.g., "data.imported"
+	// moves all packages under data.imported). Empty means no remapping.
+	Prefix string
+}
+
+// Equal returns true if two requirements are identical.
+func (r Requirement) Equal(other Requirement) bool {
+	return ptrEqual(r.Source, other.Source) &&
+		r.Path == other.Path &&
+		r.Prefix == other.Prefix
+}
+
+// Dir represents a directory on the filesystem to be included as a source.
+// It supports filtering files via include/exclude patterns and can optionally
+// wipe the directory contents before synchronization.
+type Dir struct {
+	// Path is the local filesystem path to source files (required)
+	Path string
+
+	// Wipe indicates if the directory should be deleted before synchronization.
+	// Set to false for git repositories (preserves .git directory for incremental updates).
+	// Set to true for generated/downloaded data (http, database) that should be refreshed.
+	Wipe bool
+
+	// IncludedFiles is an inclusion filter on files to load from the path.
+	// Supports glob patterns (e.g., "*.rego", "policies/**/*.rego").
+	// Empty means include all files.
+	IncludedFiles []string
+
+	// ExcludedFiles is an exclusion filter on files to skip from the path.
+	// Supports glob patterns (e.g., "*_test.rego", "temp/**").
+	// Applied after IncludedFiles.
+	ExcludedFiles []string
+}
+
+// Transform applies a Rego query to transform data files before building.
+// The query is evaluated with the file's JSON content as input, and the
+// result replaces the original file content.
+type Transform struct {
+	// Query is the Rego query to evaluate (e.g., "data.transform.result")
+	Query string
+
+	// Path is the absolute filesystem path to the JSON file to transform
+	Path string
+}
+
+func ptrEqual[T comparable](a, b *T) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}

--- a/pkg/builder/doc.go
+++ b/pkg/builder/doc.go
@@ -1,0 +1,117 @@
+// Package builder compiles OPA bundles from multiple sources with namespace isolation.
+//
+// The builder validates package namespacing (no overlapping packages allowed), merges
+// filesystems from different sources, and uses OPA's native compiler to produce optimized bundles.
+// It supports source transformations via Rego queries and requirement-based dependency management.
+//
+// # Basic Usage
+//
+// Create sources with directories and build a bundle:
+//
+//	import "github.com/open-policy-agent/opa-control-plane/pkg/builder"
+//
+//	// Create a source
+//	src := builder.NewSource("my-policies")
+//	err := src.AddDir(builder.Dir{
+//	    Path: "/path/to/policies",
+//	    Wipe: false,
+//	    IncludedFiles: []string{"*.rego"},
+//	    ExcludedFiles: []string{"*_test.rego"},
+//	})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Build bundle
+//	var output bytes.Buffer
+//	b := builder.New().
+//	    WithSources([]*builder.Source{src}).
+//	    WithOutput(&output).
+//	    WithTarget("rego") // or "wasm", "ir"
+//
+//	if err := b.Build(ctx); err != nil {
+//	    log.Fatal(err)
+//	}
+//
+// # Sources and Requirements
+//
+// Sources can depend on other sources via requirements. Requirements support
+// path mounting to avoid namespace conflicts:
+//
+//	lib := builder.NewSource("library")
+//	_ = lib.AddDir(builder.Dir{Path: "/path/to/lib"})
+//
+//	main := builder.NewSource("main")
+//	_ = main.AddDir(builder.Dir{Path: "/path/to/main"})
+//	libName := "library"
+//	main.Requirements = []builder.Requirement{{
+//	    Source: &libName,
+//	    Path:   "data.lib",      // Select this subtree from library
+//	    Prefix: "data.imported", // Mount it here in the bundle
+//	}}
+//
+//	b := builder.New().
+//	    WithSources([]*builder.Source{main, lib}).
+//	    WithOutput(&output)
+//
+//	err := b.Build(ctx)
+//
+// # Namespace Isolation
+//
+// The builder enforces strict namespace isolation. Sources with overlapping
+// package paths will cause a build error:
+//
+//	// Source A has: package x.y
+//	// Source B has: package x.y.z
+//	// Build will fail with PackageConflictErr
+//
+// Use path mounting in requirements to resolve conflicts by moving one source
+// into a different namespace:
+//
+//	main.Requirements = []builder.Requirement{{
+//	    Source: &libName,
+//	    Prefix: "data.imported", // Moves conflicting packages under "imported"
+//	}}
+//
+// # Data Transformations
+//
+// Sources can apply Rego transformations to JSON data files before building:
+//
+//	src.Transforms = []builder.Transform{{
+//	    Query: "data.transform.result", // Rego query to evaluate
+//	    Path:  "/path/to/data.json",    // File to transform
+//	}}
+//
+// The transform evaluates the query with the file's JSON as input and
+// replaces the file with the query result.
+//
+// # Build Targets
+//
+// The builder supports multiple OPA compilation targets:
+//   - "rego": Compile to Rego (default)
+//   - "wasm": Compile to WebAssembly
+//   - "ir" or "plan": Compile to intermediate representation
+//
+// Set the target with WithTarget:
+//
+//	b := builder.New().
+//	    WithSources(sources).
+//	    WithTarget("wasm").
+//	    WithOutput(&output)
+//
+// # File Filtering
+//
+// Filter files at multiple levels:
+//   - Per-source: Use Dir.IncludedFiles and Dir.ExcludedFiles
+//   - Per-bundle: Use Builder.WithExcluded to filter across all sources
+//
+//	b := builder.New().
+//	    WithSources(sources).
+//	    WithExcluded([]string{"test/**", "*.md"}). // Excludes these patterns from all sources
+//	    WithOutput(&output)
+//
+// # Thread Safety
+//
+// Builder and Source instances are NOT thread-safe. Each instance should
+// be used by a single goroutine. Create separate instances for concurrent builds.
+package builder


### PR DESCRIPTION
Move internal/builder to pkg/builder to provide a public API for OPA bundle compilation. This allows external users to build bundles from multiple sources with namespace isolation.

Changes:
- Move internal/builder -> pkg/builder
- Create pkg/builder/config.go for public configuration types
  - Requirement: source dependencies with path mounting
  - Dir: directory configuration with filters
  - Transform: Rego query transformations
- Add comprehensive documentation in pkg/builder/doc.go
- Update internal/service to use pkg/builder
- Convert internal config.Requirement to builder.Requirement

Public API:
- Builder: fluent builder with Build method
- Source: represents policy/data sources
- Requirement: minimal dependency type (no internal deps)
- Dir, Transform: configuration types
- PackageConflictErr: namespace conflict error

All tests passing. External users can now use pkg/builder without importing any internal packages.