### PR TITLE
Externalize builder package to pkg/builder

### DIFF
--- a/internal/service/worker.go
+++ b/internal/service/worker.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/open-policy-agent/opa-control-plane/internal/builder"
+	"github.com/open-policy-agent/opa-control-plane/pkg/builder"
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	"github.com/open-policy-agent/opa-control-plane/internal/logging"
 	"github.com/open-policy-agent/opa-control-plane/internal/metrics"

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -15,8 +15,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"    // nolint:staticcheck
 	"github.com/open-policy-agent/opa/bundle" // nolint:staticcheck
 
-	"github.com/open-policy-agent/opa-control-plane/internal/builder"
-	"github.com/open-policy-agent/opa-control-plane/internal/config"
+	"github.com/open-policy-agent/opa-control-plane/pkg/builder"
 	"github.com/open-policy-agent/opa-control-plane/internal/test/tempfs"
 )
 
@@ -664,9 +663,9 @@ func TestBuilder(t *testing.T) {
 
 				var srcs []*builder.Source
 				for i, src := range tc.sources {
-					var rs []config.Requirement
+					var rs []builder.Requirement
 					for _, r := range src.requirements {
-						rs = append(rs, config.Requirement{
+						rs = append(rs, builder.Requirement{
 							Source: &r.name,
 							Path:   r.path,
 							Prefix: r.prefix,

--- a/pkg/builder/config.go
+++ b/pkg/builder/config.go
@@ -1,0 +1,68 @@
+package builder
+
+// Requirement represents a dependency on another source with optional path mounting.
+// It allows sources to include other sources and remap their package namespaces
+// to avoid conflicts.
+type Requirement struct {
+	// Source is the name of the source to include (required)
+	Source *string
+
+	// Path selects a subtree from the source (e.g., "data.lib" selects only
+	// packages under data.lib). Empty means include everything.
+	Path string
+
+	// Prefix remaps the source to a different namespace (e.g., "data.imported"
+	// moves all packages under data.imported). Empty means no remapping.
+	Prefix string
+}
+
+// Equal returns true if two requirements are identical.
+func (r Requirement) Equal(other Requirement) bool {
+	return ptrEqual(r.Source, other.Source) &&
+		r.Path == other.Path &&
+		r.Prefix == other.Prefix
+}
+
+// Dir represents a directory on the filesystem to be included as a source.
+// It supports filtering files via include/exclude patterns and can optionally
+// wipe the directory contents before synchronization.
+type Dir struct {
+	// Path is the local filesystem path to source files (required)
+	Path string
+
+	// Wipe indicates if the directory should be deleted before synchronization.
+	// Set to false for git repositories (preserves .git directory for incremental updates).
+	// Set to true for generated/downloaded data (http, database) that should be refreshed.
+	Wipe bool
+
+	// IncludedFiles is an inclusion filter on files to load from the path.
+	// Supports glob patterns (e.g., "*.rego", "policies/**/*.rego").
+	// Empty means include all files.
+	IncludedFiles []string
+
+	// ExcludedFiles is an exclusion filter on files to skip from the path.
+	// Supports glob patterns (e.g., "*_test.rego", "temp/**").
+	// Applied after IncludedFiles.
+	ExcludedFiles []string
+}
+
+// Transform applies a Rego query to transform data files before building.
+// The query is evaluated with the file's JSON content as input, and the
+// result replaces the original file content.
+type Transform struct {
+	// Query is the Rego query to evaluate (e.g., "data.transform.result")
+	Query string
+
+	// Path is the absolute filesystem path to the JSON file to transform
+	Path string
+}
+
+func ptrEqual[T comparable](a, b *T) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}

--- a/pkg/builder/doc.go
+++ b/pkg/builder/doc.go
@@ -1,0 +1,117 @@
+// Package builder compiles OPA bundles from multiple sources with namespace isolation.
+//
+// The builder validates package namespacing (no overlapping packages allowed), merges
+// filesystems from different sources, and uses OPA's native compiler to produce optimized bundles.
+// It supports source transformations via Rego queries and requirement-based dependency management.
+//
+// # Basic Usage
+//
+// Create sources with directories and build a bundle:
+//
+//	import "github.com/open-policy-agent/opa-control-plane/pkg/builder"
+//
+//	// Create a source
+//	src := builder.NewSource("my-policies")
+//	err := src.AddDir(builder.Dir{
+//	    Path: "/path/to/policies",
+//	    Wipe: false,
+//	    IncludedFiles: []string{"*.rego"},
+//	    ExcludedFiles: []string{"*_test.rego"},
+//	})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Build bundle
+//	var output bytes.Buffer
+//	b := builder.New().
+//	    WithSources([]*builder.Source{src}).
+//	    WithOutput(&output).
+//	    WithTarget("rego") // or "wasm", "ir"
+//
+//	if err := b.Build(ctx); err != nil {
+//	    log.Fatal(err)
+//	}
+//
+// # Sources and Requirements
+//
+// Sources can depend on other sources via requirements. Requirements support
+// path mounting to avoid namespace conflicts:
+//
+//	lib := builder.NewSource("library")
+//	_ = lib.AddDir(builder.Dir{Path: "/path/to/lib"})
+//
+//	main := builder.NewSource("main")
+//	_ = main.AddDir(builder.Dir{Path: "/path/to/main"})
+//	libName := "library"
+//	main.Requirements = []builder.Requirement{{
+//	    Source: &libName,
+//	    Path:   "data.lib",      // Select this subtree from library
+//	    Prefix: "data.imported", // Mount it here in the bundle
+//	}}
+//
+//	b := builder.New().
+//	    WithSources([]*builder.Source{main, lib}).
+//	    WithOutput(&output)
+//
+//	err := b.Build(ctx)
+//
+// # Namespace Isolation
+//
+// The builder enforces strict namespace isolation. Sources with overlapping
+// package paths will cause a build error:
+//
+//	// Source A has: package x.y
+//	// Source B has: package x.y.z
+//	// Build will fail with PackageConflictErr
+//
+// Use path mounting in requirements to resolve conflicts by moving one source
+// into a different namespace:
+//
+//	main.Requirements = []builder.Requirement{{
+//	    Source: &libName,
+//	    Prefix: "data.imported", // Moves conflicting packages under "imported"
+//	}}
+//
+// # Data Transformations
+//
+// Sources can apply Rego transformations to JSON data files before building:
+//
+//	src.Transforms = []builder.Transform{{
+//	    Query: "data.transform.result", // Rego query to evaluate
+//	    Path:  "/path/to/data.json",    // File to transform
+//	}}
+//
+// The transform evaluates the query with the file's JSON as input and
+// replaces the file with the query result.
+//
+// # Build Targets
+//
+// The builder supports multiple OPA compilation targets:
+//   - "rego": Compile to Rego (default)
+//   - "wasm": Compile to WebAssembly
+//   - "ir" or "plan": Compile to intermediate representation
+//
+// Set the target with WithTarget:
+//
+//	b := builder.New().
+//	    WithSources(sources).
+//	    WithTarget("wasm").
+//	    WithOutput(&output)
+//
+// # File Filtering
+//
+// Filter files at multiple levels:
+//   - Per-source: Use Dir.IncludedFiles and Dir.ExcludedFiles
+//   - Per-bundle: Use Builder.WithExcluded to filter across all sources
+//
+//	b := builder.New().
+//	    WithSources(sources).
+//	    WithExcluded([]string{"test/**", "*.md"}). // Excludes these patterns from all sources
+//	    WithOutput(&output)
+//
+// # Thread Safety
+//
+// Builder and Source instances are NOT thread-safe. Each instance should
+// be used by a single goroutine. Create separate instances for concurrent builds.
+package builder


### PR DESCRIPTION
Move internal/builder to pkg/builder to provide a public API for OPA bundle compilation. This allows external users to build bundles from multiple sources with namespace isolation.

Changes:
- Move internal/builder -> pkg/builder
- Create pkg/builder/config.go for public configuration types
  - Requirement: source dependencies with path mounting
  - Dir: directory configuration with filters
  - Transform: Rego query transformations
- Add comprehensive documentation in pkg/builder/doc.go
- Update internal/service to use pkg/builder
- Convert internal config.Requirement to builder.Requirement

Public API:
- Builder: fluent builder with Build method
- Source: represents policy/data sources
- Requirement: minimal dependency type (no internal deps)
- Dir, Transform: configuration types
- PackageConflictErr: namespace conflict error

All tests passing. External users can now use pkg/builder without importing any internal packages.