### PR TITLE
Externalize bundle builder

### DIFF
--- a/internal/config/secret.go
+++ b/internal/config/secret.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/goccy/go-yaml"
+	"github.com/open-policy-agent/opa-control-plane/internal/util"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -113,7 +114,7 @@ func (s *Secret) UnmarshalJSON(bs []byte) error {
 }
 
 func (s *Secret) Equal(other *Secret) bool {
-	return fastEqual(s, other, func(s, other *Secret) bool {
+	return util.FastEqual(s, other, func(s, other *Secret) bool {
 		return s.Name == other.Name &&
 			reflect.DeepEqual(s.Value, other.Value)
 	})

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -20,7 +20,6 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 	_ "modernc.org/sqlite"
 
-	"github.com/open-policy-agent/opa-control-plane/internal/builder"
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	"github.com/open-policy-agent/opa-control-plane/internal/database"
 	ocp_fs "github.com/open-policy-agent/opa-control-plane/internal/fs"
@@ -32,6 +31,7 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/progress"
 	"github.com/open-policy-agent/opa-control-plane/internal/s3"
 	"github.com/open-policy-agent/opa-control-plane/internal/sqlsync"
+	"github.com/open-policy-agent/opa-control-plane/pkg/builder"
 )
 
 const (

--- a/internal/service/worker.go
+++ b/internal/service/worker.go
@@ -6,12 +6,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/open-policy-agent/opa-control-plane/internal/builder"
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	"github.com/open-policy-agent/opa-control-plane/internal/logging"
 	"github.com/open-policy-agent/opa-control-plane/internal/metrics"
 	"github.com/open-policy-agent/opa-control-plane/internal/progress"
 	"github.com/open-policy-agent/opa-control-plane/internal/s3"
+	"github.com/open-policy-agent/opa-control-plane/pkg/builder"
 )
 
 var (

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,76 @@
+package util
+
+import (
+	"cmp"
+	"maps"
+)
+
+func SetEqual[K comparable, V any](a, b []V, key func(V) K, eq func(a, b V) bool) bool {
+	if len(a) == 1 && len(b) == 1 {
+		return eq(a[0], b[0])
+	}
+
+	// NB(sr): There's a risk of false positives here, e.g. []struct{n, v string}{ {"foo", "bar"}, {"foo", "baz"} }
+	// is setEqual to []struct{n, v string}{ {"foo", "baz"} }
+	m := make(map[K]V, len(a))
+	for _, v := range a {
+		m[key(v)] = v
+	}
+
+	n := make(map[K]V, len(b))
+	for _, v := range b {
+		n[key(v)] = v
+	}
+
+	return maps.EqualFunc(m, n, eq)
+}
+
+func PtrEqual[T comparable](a, b *T) bool {
+	return FastEqual(a, b, func(a, b *T) bool { return *a == *b })
+}
+
+func BoolPtrCompare(a, b *bool) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	case !*a && *b:
+		return -1
+	case *a && !*b:
+		return 1
+	}
+
+	return 0
+}
+
+func PtrCompare[T cmp.Ordered](a, b *T) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	case *a < *b:
+		return -1
+	case *a > *b:
+		return 1
+	}
+
+	return 0
+}
+
+func FastEqual[V any](a, b *V, slowEqual func(a, b *V) bool) bool {
+	if a == b {
+		return true
+	}
+
+	if a == nil || b == nil {
+		return false
+	}
+
+	return slowEqual(a, b)
+}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -28,11 +28,15 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	ocp_fs "github.com/open-policy-agent/opa-control-plane/internal/fs"
 	"github.com/open-policy-agent/opa-control-plane/internal/fs/mountfs"
+	ext_config "github.com/open-policy-agent/opa-control-plane/pkg/config"
 )
 
+// Source represents a collection of policy and data files with dependencies.
+// Sources can depend on other sources via Requirements and apply transformations
+// to data files before building.
 type Source struct {
 	Name         string
-	Requirements []config.Requirement
+	Requirements []ext_config.Requirement
 	Transforms   []Transform
 
 	// dirs record the underlying OS directories, used for `Wipe` and `Transform`
@@ -43,6 +47,8 @@ type Source struct {
 	fses []fs.FS
 }
 
+// Transform defines a data transformation operation that uses a Rego query to
+// process and modify data files within a source.
 type Transform struct {
 	Query string
 	Path  string

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/open-policy-agent/opa/ast"    // nolint:staticcheck
 	"github.com/open-policy-agent/opa/bundle" // nolint:staticcheck
 
-	"github.com/open-policy-agent/opa-control-plane/internal/builder"
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	"github.com/open-policy-agent/opa-control-plane/internal/test/tempfs"
+	"github.com/open-policy-agent/opa-control-plane/pkg/builder"
 )
 
 func TestBuilder(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"strings"
+
+	internalutil "github.com/open-policy-agent/opa-control-plane/internal/util"
+)
+
+// Requirement specifies a dependency on a source (such as a Git repository)
+// with optional constraints for how it should be resolved and mounted.
+type Requirement struct {
+	Source    *string        `json:"source,omitempty"`
+	Git       GitRequirement `json:"git,omitzero"`
+	Path      string         `json:"path,omitzero"`
+	Prefix    string         `json:"prefix,omitzero"`
+	AutoMount *bool          `json:"automount,omitempty"`
+
+	_ struct{} `additionalProperties:"false"`
+}
+
+// GitRequirement specifies Git-specific constraints for a requirement.
+// It allows pinning a dependency to a specific Git commit hash.
+type GitRequirement struct {
+	Commit *string `json:"commit,omitempty"`
+
+	_ struct{} `additionalProperties:"false"`
+}
+
+func (a Requirement) Equal(b Requirement) bool {
+	return internalutil.PtrEqual(a.Source, b.Source) &&
+		internalutil.PtrEqual(a.Git.Commit, b.Git.Commit) &&
+		a.Path == b.Path &&
+		a.Prefix == b.Prefix &&
+		internalutil.PtrEqual(a.AutoMount, b.AutoMount)
+}
+func (a Requirement) Compare(b Requirement) int {
+	if x := internalutil.PtrCompare(a.Source, b.Source); x != 0 {
+		return x
+	}
+	if x := internalutil.PtrCompare(a.Git.Commit, b.Git.Commit); x != 0 {
+		return x
+	}
+	if x := strings.Compare(a.Path, b.Path); x != 0 {
+		return x
+	}
+	if x := strings.Compare(a.Prefix, b.Prefix); x != 0 {
+		return x
+	}
+	if x := internalutil.BoolPtrCompare(a.AutoMount, b.AutoMount); x != 0 {
+		return x
+	}
+	return 0
+}


### PR DESCRIPTION
The bundle builder implementation, which compiles OPA bundles from policy and data files stored in Git repositories for ex, was previously located in `internal/builder` and not accessible to external consumers.

This change moves the builder package from `internal/builder` to `pkg/builder`, making it part of the public API. This allows users and external tools to programmatically build OPA bundles.