### PR TITLE
dependabot: skip open-policy-agent/opa (for now)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,8 @@ updates:
       all:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "github.com/open-policy-agent/opa"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
We're using `main`, let's bring this back after the next OPA release.