### PR TITLE
server: support listening on a unix socket

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -83,7 +83,7 @@ func init() {
 	}
 
 	flags.AddConfig(run.Flags(), &params.configFile)
-	run.Flags().StringVarP(&params.addr, "addr", "a", defaultLocalAddr, "Set listening address of the server")
+	run.Flags().StringVarP(&params.addr, "addr", "a", defaultLocalAddr, "Set listening address of the server (e.g., localhost:8282, unix:///tmp/ocp.sock, or /tmp/ocp.sock)")
 	run.Flags().StringVarP(&params.persistenceDir, "data-dir", "d", "data", "Path to the persistence directory")
 	run.Flags().BoolVarP(&params.resetPersistence, "reset-persistence", "", false, "Reset the persistence directory (for development purposes)")
 	run.Flags().BoolVarP(&params.mergeConflictFail, "merge-conflict-fail", "", false, "Fail on config merge conflicts")

--- a/e2e/cli/run_api_prefix.txtar
+++ b/e2e/cli/run_api_prefix.txtar
@@ -1,23 +1,23 @@
-exec $OPACTL run --addr 127.0.0.1:8284 --config config.d/bundle.yml --data-dir tmp-api-prefix &opactl&
+exec $OPACTL run --addr ./ocp.sock --config config.d/bundle.yml --data-dir tmp-api-prefix &opactl&
 ! stderr .
 ! stdout .
 
-exec curl --retry 5 --retry-all-errors http://127.0.0.1:8284/my/api/health
+exec curl --retry 5 --retry-all-errors --unix-socket ocp.sock http://localhost/my/api/health
 stdout '\{\}'
 
-exec curl --retry 5 --retry-all-errors -H 'Authorization: Bearer admin-token' http://127.0.0.1:8284/my/api/v1/bundles
+exec curl --retry 5 --retry-all-errors --unix-socket ocp.sock -H 'Authorization: Bearer admin-token' http://localhost/my/api/v1/bundles
 stdout '\{\}'
 
-exec curl --retry 5 --retry-all-errors -H 'Authorization: Bearer admin-token' http://127.0.0.1:8284/my/api/v1/sources
+exec curl --retry 5 --retry-all-errors --unix-socket ocp.sock -H 'Authorization: Bearer admin-token' http://localhost/my/api/v1/sources
 stdout '\{\}'
 
-exec curl --retry 5 --retry-all-errors -H 'Authorization: Bearer admin-token' http://127.0.0.1:8284/my/api/v1/stacks
+exec curl --retry 5 --retry-all-errors --unix-socket ocp.sock -H 'Authorization: Bearer admin-token' http://localhost/my/api/v1/stacks
 
-exec curl --retry 5 --retry-all-errors http://127.0.0.1:8284/my/api/metrics
+exec curl --retry 5 --retry-all-errors --unix-socket ocp.sock http://localhost/my/api/metrics
 stdout '/my/api'
 
-! exec curl -f --retry 1 --retry-all-errors http://127.0.0.1:8284/health
-! exec curl -f --retry 1 --retry-all-errors -H 'Authorization: Bearer admin-token' http://127.0.0.1:8284/v1/bundles
+! exec curl -f --retry 1 --retry-all-errors --unix-socket ocp.sock http://localhost/health
+! exec curl -f --retry 1 --retry-all-errors --unix-socket ocp.sock -H 'Authorization: Bearer admin-token' http://localhost/v1/bundles
 
 kill opactl
 

--- a/e2e/cli/run_basic.txtar
+++ b/e2e/cli/run_basic.txtar
@@ -1,6 +1,6 @@
-! exec $OPACTL run --config config.d/bundle.yml --data-dir tmp &opactl&
+! exec $OPACTL run --addr ./ocp.sock --config config.d/bundle.yml --data-dir tmp &opactl&
 
-exec curl --retry 5 --retry-all-errors http://127.0.0.1:8282/health
+exec curl --retry 5 --retry-all-errors --unix-socket ocp.sock http://localhost/health
 
 kill opactl
 wait opactl

--- a/e2e/cli/run_env_vars.txtar
+++ b/e2e/cli/run_env_vars.txtar
@@ -1,10 +1,10 @@
 env API_TOKEN=sesame
 env SQLITE_FILE=sqlite123.db
 env
-! exec $OPACTL run --addr :8383 --config config.d/bundle.yml &opactl&
+! exec $OPACTL run --addr ./ocp.sock --config config.d/bundle.yml &opactl&
 
-exec curl --retry 5 --retry-all-errors http://127.0.0.1:8383/health
-exec curl -H 'Authorization: bearer sesame' http://127.0.0.1:8383/v1/bundles
+exec curl --retry 5 --retry-all-errors --unix-socket ocp.sock http://localhost/health
+exec curl --unix-socket ocp.sock -H 'Authorization: bearer sesame' http://localhost/v1/bundles
 
 kill opactl
 wait opactl

--- a/e2e/cli/run_git_bundle_build.txtar
+++ b/e2e/cli/run_git_bundle_build.txtar
@@ -11,12 +11,12 @@ exec git add .
 exec git commit -m initial-commit
 cd ..
 
-exec $OPACTL run --addr 127.0.0.1:8283 --config config.d/bundle.yml --data-dir tmp1 &opactl&
+exec $OPACTL run --addr ./ocp.sock --config config.d/bundle.yml --data-dir tmp1 &opactl&
 ! stderr .
 ! stdout .
 
-exec curl --retry 5 --retry-all-errors http://127.0.0.1:8283/health
-exec curl http://127.0.0.1:8283/metrics
+exec curl --retry 5 --retry-all-errors --unix-socket ocp.sock http://localhost/health
+exec curl --unix-socket ocp.sock http://localhost/metrics
 
 # assert git sync and bundle build metrics
 stdout 'ocp_git_sync_count_total{repo="./repo/",source="git-data",state="SUCCESS"} 1'


### PR DESCRIPTION
At least for testing, this simplifies some things: we no longer need to assume one specific port for each test so that concurrent tests don't mess with one another.