### PR TITLE
builder: record placeholder roots for sources with `prefix`

### DIFF
--- a/e2e/cli/build_empty_dir_source_prefix.txtar
+++ b/e2e/cli/build_empty_dir_source_prefix.txtar
@@ -1,0 +1,33 @@
+# Test that a directory source with no files alongside a source with rego
+# files produces a placeholder root from the prefix.
+exec mkdir empty_src
+exec $OPACTL build --config config.d/bundle.yml --data-dir tmp --non-interactive
+! stderr .
+! stdout .
+
+exec tar xf bundles/hello-world/bundle.tar.gz
+cmp .manifest exp/.manifest
+
+-- policy/rules.rego --
+package rules
+import rego.v1
+allow if input.admin
+-- config.d/bundle.yml --
+bundles:
+  hello-world:
+    object_storage:
+      filesystem:
+        path: bundles/hello-world/bundle.tar.gz
+    requirements:
+    - source: policy
+    - source: empty-data
+      prefix: ext
+sources:
+  policy:
+    directory: policy
+    paths:
+    - '*.rego'
+  empty-data:
+    directory: empty_src
+-- exp/.manifest --
+{"revision":"","roots":["rules","ext"],"rego_version":0}

--- a/e2e/cli/build_empty_source_prefix.txtar
+++ b/e2e/cli/build_empty_source_prefix.txtar
@@ -1,0 +1,58 @@
+# Test that an empty SQL source with a prefix produces a root for that prefix,
+# and that pushing data updates the roots correctly.
+! exec $OPACTL run --config config.d/bundle.yml --data-dir tmp --addr ./ocp.sock &opactl&
+
+exec curl --retry 5 --retry-all-errors --unix-socket ocp.sock http://localhost/health
+
+# Wait for initial build with empty source
+retry tar tf bundles/hello-world/bundle.tar.gz
+
+# Verify the empty source produced "abc" as root, not [""]
+exec tar xf bundles/hello-world/bundle.tar.gz
+cmp .manifest exp/manifest-empty
+cmp data.json exp/empty-data.json
+exec rm bundles/hello-world/bundle.tar.gz
+
+# Push data to the source (prefix mount will place it under abc/)
+exec curl --unix-socket ocp.sock -X PUT http://localhost/v1/sources/sql-source/data/users -H 'Authorization: Bearer test-key' -d '{"alice":{"role":"admin"}}'
+
+# Wait for rebuild cycle
+retry tar tf bundles/hello-world/bundle.tar.gz
+
+kill opactl
+wait opactl
+
+# Verify the roots now reflect the actual data under the prefix
+exec tar xf bundles/hello-world/bundle.tar.gz
+cmp .manifest exp/manifest-with-data
+cmp data.json exp/data.json
+
+-- config.d/bundle.yml --
+database:
+  sql:
+    driver: sqlite
+    dsn: sqlite.db
+tokens:
+  test-token:
+    api_key: test-key
+    scopes:
+    - role: administrator
+bundles:
+  hello-world:
+    rebuild_interval: 1s
+    object_storage:
+      filesystem:
+        path: bundles/hello-world/bundle.tar.gz
+    requirements:
+    - source: sql-source
+      prefix: abc
+sources:
+  sql-source: {}
+-- exp/manifest-empty --
+{"revision":"","roots":["abc"],"rego_version":0}
+-- exp/empty-data.json --
+{}
+-- exp/manifest-with-data --
+{"revision":"","roots":["abc/users"],"rego_version":0}
+-- exp/data.json --
+{"abc":{"users":{"alice":{"role":"admin"}}}}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -302,6 +302,8 @@ func (b *Builder) Build(ctx context.Context) error {
 	alreadyProcessed := []mntSrc{}
 	rootMap := map[string]*Source{}
 
+	var emptyMntSrcs []mntSrc
+
 	for len(toProcess) > 0 {
 		var next mntSrc
 		next, toProcess = toProcess[0], toProcess[1:]
@@ -348,6 +350,13 @@ func (b *Builder) Build(ctx context.Context) error {
 			newRoots.add(rs...)
 		}
 
+		hasSourceReqs := slices.ContainsFunc(next.src.Requirements, func(r ext_config.Requirement) bool {
+			return r.Source != nil
+		})
+		if len(newRoots.refs) == 0 && len(next.mounts) > 0 && !hasSourceReqs {
+			emptyMntSrcs = append(emptyMntSrcs, next)
+		}
+
 		for _, root := range newRoots.refs {
 			if overlap := rootsOverlap(existingRoots, root); len(overlap) > 0 {
 				return &PackageConflictErr{
@@ -381,6 +390,29 @@ func (b *Builder) Build(ctx context.Context) error {
 				}
 			}
 		}
+	}
+
+	// For empty sources with mount prefixes, derive roots so the bundle
+	// claims the configured namespaces instead of letting OPA default to
+	// roots:[""] (which conflicts with every other bundle). This mirrors
+	// applyDataMounts: each mount in the chain applies Sub(path) then
+	// Mount(prefix). For an empty source, a non-trivial path selects a
+	// subtree that doesn't exist, collapsing the chain to nothing.
+	for _, ms := range emptyMntSrcs {
+		root := mountRoot(ms.mounts)
+		if root == nil {
+			continue
+		}
+		if overlap := rootsOverlap(existingRoots, root); len(overlap) > 0 {
+			return &PackageConflictErr{
+				Requirement: ms.src,
+				Package:     &ast.Package{Path: root},
+				rootMap:     rootMap,
+				overlap:     overlap,
+			}
+		}
+		rootMap[root.String()] = ms.src
+		existingRoots = append(existingRoots, root)
 	}
 
 	roots := make([]string, 0, len(existingRoots))
@@ -659,6 +691,53 @@ func applyDataMounts(fsys fs.FS, mnts []mount) (fs.FS, error) {
 		fs1 = sub
 	}
 	return fs1, nil
+}
+
+// mountRoot simulates the mount chain on an empty source to determine the
+// effective root namespace. It mirrors applyDataMounts: each mount applies
+// Sub(path) then Mount(prefix). For an empty source the "data space" is just
+// the root (data). A non-trivial path selects a subtree that doesn't exist,
+// collapsing the result to nil.
+func mountRoot(mnts []mount) ast.Ref {
+	cur := ast.DefaultRootRef.Copy() // [data]
+	for _, mnt := range mnts {
+		subRef := toRef(mnt.path)
+		prefRef := toRef(mnt.prefix)
+		if subRef == nil || prefRef == nil {
+			return nil
+		}
+
+		// Sub: selecting a subtree from an empty source yields nothing
+		// unless the virtual cursor is already at or below the sub path.
+		// When cur equals DefaultRootRef, a deeper subRef selects content
+		// that doesn't exist in an empty source.
+		if !cur.HasPrefix(subRef) {
+			return nil
+		}
+		cur = ast.DefaultRootRef.Concat(cur[len(subRef):])
+
+		// Mount: place cur under prefRef.
+		cur = prefRef.Concat(cur[1:]) // [1:] drops "data" head from cur
+	}
+
+	if cur.Equal(ast.DefaultRootRef) {
+		return nil // no effective prefix — would default to root
+	}
+	return cur
+}
+
+// toRef parses a mount path or prefix (e.g. "data.x.y" or "") into an ast.Ref.
+// Returns DefaultRootRef for empty/root values.
+func toRef(d string) ast.Ref {
+	d = toRefString(d)
+	r, err := ast.ParseRef(d)
+	if err != nil {
+		return nil
+	}
+	if !r.HasPrefix(ast.DefaultRootRef) {
+		return nil
+	}
+	return r
 }
 
 var offlineCaps = offlineCapabilities()

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -30,6 +31,7 @@ func TestBuilder(t *testing.T) {
 	type sourceMock struct {
 		name          string
 		files         map[string]string
+		hasDir        bool // create an (empty) directory even without files
 		requirements  []reqMock
 		includedFiles []string
 		excludedFiles []string
@@ -632,6 +634,97 @@ func TestBuilder(t *testing.T) {
 			expRoots: []string{"x", "lib/y"},
 		},
 		{
+			note: "empty source with prefix alongside source with files",
+			sources: []sourceMock{
+				{
+					name:  "primary",
+					files: map[string]string{"/x.rego": "package x\np := true"},
+					requirements: []reqMock{
+						{name: "empty_src", prefix: "abc"},
+					},
+				},
+				{
+					name:  "empty_src",
+					files: map[string]string{},
+				},
+			},
+			exp: map[string]string{
+				"/primary/x.rego": "package x\np := true",
+			},
+			expRoots: []string{"x", "abc"},
+		},
+		{
+			note: "empty source with prefix produces prefix root",
+			sources: []sourceMock{
+				{
+					name:         "primary",
+					files:        map[string]string{},
+					requirements: []reqMock{{name: "empty_src", prefix: "abc"}},
+				},
+				{
+					name:  "empty_src",
+					files: map[string]string{},
+				},
+			},
+			expRoots: []string{"abc"},
+		},
+		{
+			note: "empty directory source with prefix produces prefix root",
+			sources: []sourceMock{
+				{
+					name:         "primary",
+					files:        map[string]string{},
+					requirements: []reqMock{{name: "empty_dir", prefix: "abc"}},
+				},
+				{
+					name:   "empty_dir",
+					hasDir: true,
+					files:  map[string]string{},
+				},
+			},
+			expRoots: []string{"abc"},
+		},
+		{
+			note: "empty source with transitive prefix chain",
+			sources: []sourceMock{
+				{
+					name:         "primary",
+					files:        map[string]string{},
+					requirements: []reqMock{{name: "middle", prefix: "top"}},
+				},
+				{
+					name:         "middle",
+					files:        map[string]string{},
+					requirements: []reqMock{{name: "leaf", prefix: "inner"}},
+				},
+				{
+					name:  "leaf",
+					files: map[string]string{},
+				},
+			},
+			expRoots: []string{"top/inner"},
+		},
+		{
+			note: "empty source with path and prefix that cancel out",
+			sources: []sourceMock{
+				{
+					name:         "primary",
+					files:        map[string]string{},
+					requirements: []reqMock{{name: "middle", path: "data.x"}}, // removes x
+				},
+				{
+					name:         "middle",
+					files:        map[string]string{},
+					requirements: []reqMock{{name: "leaf", prefix: "data.x.y"}}, // prepends data.x.y
+				},
+				{
+					name:  "leaf",
+					files: map[string]string{},
+				},
+			},
+			expRoots: []string{"y"}, // "y" stays around, only "x" is cancelled out
+		},
+		{
 			note: "roots inferred from directory structure for data files",
 			sources: []sourceMock{
 				{
@@ -660,6 +753,16 @@ func TestBuilder(t *testing.T) {
 
 			tempfs.WithTempFS(t, allFiles, func(t *testing.T, root string) {
 
+				// Create empty directories for hasDir sources that have
+				// no files, matching what the SQL sync does in production.
+				for i, src := range tc.sources {
+					if src.hasDir && len(src.files) == 0 {
+						if err := os.MkdirAll(fmt.Sprintf("%v/src%d", root, i), 0o755); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+
 				buf := bytes.NewBuffer(nil)
 
 				var srcs []*builder.Source
@@ -674,7 +777,7 @@ func TestBuilder(t *testing.T) {
 					}
 					s := builder.NewSource(src.name)
 					s.Requirements = rs
-					if len(src.files) > 0 {
+					if len(src.files) > 0 || src.hasDir {
 						_ = s.AddDir(builder.Dir{
 							Path:          fmt.Sprintf("%v/src%d", root, i),
 							IncludedFiles: src.includedFiles,


### PR DESCRIPTION
...while respecting `path` and transitive application thereof.

Also adjusts fs sources without actual policies in them (see added tests).

Fixes #312.