### PR TITLE
Add bundle lifecycle status tracking (build, push)

### DIFF
--- a/internal/authz/authz.rego
+++ b/internal/authz/authz.rego
@@ -19,6 +19,7 @@ allow if {
 		"stacks.view",
 		"tokens.view",
 		"sources.data.read",
+		"bundles.statuses.view",
 	]
 }
 

--- a/internal/authz/authz_test.rego
+++ b/internal/authz/authz_test.rego
@@ -19,6 +19,7 @@ read_permissions := {
 	"secrets.view",
 	"tokens.view",
 	"sources.data.read",
+	"bundles.statuses.view",
 }
 
 test_viewer_can_view_anything if {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ import (
 // to continue using the short names (e.g. config.Bundle) while the canonical
 // definitions live in the public package.
 type (
+	BundleStatus      = extconfig.BundleStatus
 	Bundle            = extconfig.Bundle
 	Source            = extconfig.Source
 	Sources           = extconfig.Sources

--- a/internal/database/bundle_status.go
+++ b/internal/database/bundle_status.go
@@ -1,0 +1,197 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/open-policy-agent/opa-control-plane/pkg/config"
+)
+
+const MaxBundleStatusRetention = 10
+
+// UpsertBundleStatus creates or updates a bundle status record with the given phase and status.
+// For a given tenant+bundle+revision combination, only one record exists.
+// If a record already exists for the combination, it updates the phase and status.
+// Old records beyond the retention limit (MaxBundleStatusRetention) are cleaned up in the same transaction.
+func (d *Database) UpsertBundleStatus(ctx context.Context, tenant, bundle, revision, phase, status, errMsg string) (int, error) {
+	if revision == "" {
+		return 0, errors.New("error inserting bundle status: revision is required")
+	}
+
+	var id int
+	err := tx1(ctx, d, func(tx *sql.Tx) error {
+
+		bundleID, err := d.lookupID(ctx, tx, tenant, "bundles", bundle)
+		if err != nil {
+			return fmt.Errorf("error looking up bundle %s: %w", bundle, err)
+		}
+
+		resID, err := d.upsertReturning(ctx, true, true, tx, tenant, "bundles_statuses", []string{"bundle_id", "revision", "phase", "status", "error_message"}, []string{"bundle_id", "revision"},
+			bundleID, revision, phase, status, errMsg)
+		if err != nil {
+			return fmt.Errorf("error inserting bundle status: %w", err)
+		}
+		id = resID
+
+		// Cleanup: keep only the last MaxBundleStatusRetention records per tenant+bundle_id.
+		// This runs in the same transaction to ensure consistency.
+		//
+		// Find the ID of the oldest record we want to keep and then delete everything older.
+		var cutoffID int64
+		err = tx.QueryRowContext(ctx,
+			fmt.Sprintf(
+				`SELECT bundles_statuses.id FROM bundles_statuses
+				 JOIN tenants ON tenants.id = bundles_statuses.tenant_id
+				 WHERE tenants.name = %s AND bundles_statuses.bundle_id = %s
+				 ORDER BY bundles_statuses.id DESC
+				 LIMIT 1 OFFSET %s`,
+				d.arg(0), d.arg(1), d.arg(2),
+			),
+			tenant, bundleID, MaxBundleStatusRetention-1,
+		).Scan(&cutoffID)
+
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("error finding cutoff for bundle status cleanup: %w", err)
+		}
+
+		// If we found a cutoff, delete all records older than it.
+		if err == nil {
+			_, err = tx.ExecContext(ctx,
+				fmt.Sprintf(
+					`DELETE FROM bundles_statuses WHERE bundle_id = %s AND id < %s`,
+					d.arg(0), d.arg(1),
+				),
+				bundleID, cutoffID,
+			)
+			if err != nil {
+				return fmt.Errorf("error cleaning up old bundle statuses: %w", err)
+			}
+		}
+
+		return nil
+	})
+	return id, err
+}
+
+// GetBundleStatus retrieves a single bundle state record by ID.
+func (d *Database) GetBundleStatus(ctx context.Context, id int) (*config.BundleStatus, error) {
+	var s config.BundleStatus
+	err := tx1(ctx, d, func(tx *sql.Tx) error {
+		err := tx.QueryRowContext(ctx,
+			`SELECT id, tenant_id, bundle_id, revision, phase, status, error_message, created_at
+			 FROM bundles_statuses
+			 WHERE id = `+d.arg(0),
+			id,
+		).Scan(
+			&s.ID, &s.TenantID, &s.BundleID, &s.Revision, &s.Phase, &s.Status,
+			&s.ErrorMessage, &s.CreatedAt,
+		)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("error querying bundle status by id: %w", err)
+		}
+		return nil
+
+	})
+
+	return &s, err
+}
+
+// GetLatestBundleStatus returns the most recent status record for the given tenant and bundle
+// across all revisions. Returns nil and ErrNotFound if no records exist.
+func (d *Database) GetLatestBundleStatus(ctx context.Context, principal, tenant, bundle string) (*config.BundleStatus, error) {
+	statuses, err := d.ListBundleStatuses(ctx, principal, tenant, bundle, "", 1)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(statuses) == 0 {
+		return nil, ErrNotFound
+	}
+
+	return statuses[0], nil
+}
+
+// ListBundleStatuses returns bundle status records for the given tenant and bundle,
+// ordered by bundle status id DESC. If revision is provided, results are filtered by revision.
+// If revision is empty, returns records across all revisions.
+// A limit of 0 defaults to MaxBundleStatusRetention; values above MaxBundleStatusRetention are capped.
+func (d *Database) ListBundleStatuses(ctx context.Context, principal, tenant, bundle, revision string, limit int) ([]*config.BundleStatus, error) {
+
+	// Apply default and cap for limit.
+	if limit <= 0 {
+		limit = MaxBundleStatusRetention
+	}
+	if limit > MaxBundleStatusRetention {
+		limit = MaxBundleStatusRetention
+	}
+
+	var statuses []*config.BundleStatus
+
+	err := tx1(ctx, d, func(tx *sql.Tx) error {
+		ad := d.accessFactory().WithPrincipal(principal).WithTenant(tenant).WithResource("bundles_statuses").WithPermission("bundles.statuses.view").WithName(bundle)
+		if !d.authorizer.Check(ctx, tx, d.arg, ad) {
+			return ErrNotAuthorized
+		}
+
+		bundleID, err := d.lookupID(ctx, tx, tenant, "bundles", bundle)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("error looking up bundle %s: %w", bundle, err)
+		}
+
+		var query string
+		var args []any
+
+		if revision != "" {
+			query = fmt.Sprintf(
+				`SELECT bundles_statuses.id, tenant_id, bundle_id, revision, phase, status, error_message, created_at
+				 FROM bundles_statuses
+				 JOIN tenants ON tenants.id = bundles_statuses.tenant_id
+				 WHERE tenants.name = %s AND bundle_id = %s AND revision = %s
+				 ORDER BY bundles_statuses.id DESC
+				 LIMIT %s`,
+				d.arg(0), d.arg(1), d.arg(2), d.arg(3),
+			)
+			args = []any{tenant, bundleID, revision, limit}
+		} else {
+			query = fmt.Sprintf(
+				`SELECT bundles_statuses.id, tenant_id, bundle_id, revision, phase, status, error_message, created_at
+				 FROM bundles_statuses
+				 JOIN tenants ON tenants.id = bundles_statuses.tenant_id
+				 WHERE tenants.name = %s AND bundle_id = %s
+				 ORDER BY bundles_statuses.id DESC
+				 LIMIT %s`,
+				d.arg(0), d.arg(1), d.arg(2),
+			)
+			args = []any{tenant, bundleID, limit}
+		}
+
+		rows, err := tx.Query(query, args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var s config.BundleStatus
+			if err := rows.Scan(
+				&s.ID, &s.TenantID, &s.BundleID, &s.Revision, &s.Phase, &s.Status,
+				&s.ErrorMessage, &s.CreatedAt,
+			); err != nil {
+				return fmt.Errorf("error scanning bundle status: %w", err)
+			}
+			s.BundleName = bundle
+			statuses = append(statuses, &s)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("error iterating bundle statuses: %w", err)
+		}
+		return nil
+	})
+
+	return statuses, err
+}

--- a/internal/database/bundle_status_test.go
+++ b/internal/database/bundle_status_test.go
@@ -1,0 +1,925 @@
+package database_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+
+	"github.com/open-policy-agent/opa-control-plane/internal/config"
+	"github.com/open-policy-agent/opa-control-plane/internal/database"
+	"github.com/open-policy-agent/opa-control-plane/internal/logging"
+	"github.com/open-policy-agent/opa-control-plane/internal/migrations"
+	"github.com/open-policy-agent/opa-control-plane/internal/test/dbs"
+)
+
+// Bundle status phases
+const (
+	PhaseSyncBundle  = "sync"
+	PhaseBuildBundle = "build"
+	PhasePushBundle  = "push"
+)
+
+// Bundle status states
+const (
+	StatusInProgress = "in_progress"
+	StatusCompleted  = "completed"
+	StatusFailed     = "failed"
+)
+
+const maxBundleStatusRetention = database.MaxBundleStatusRetention
+
+func TestInsertBundleStatusNew(t *testing.T) {
+	ctx := context.Background()
+
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				if databaseConfig.Cleanup != nil {
+					t.Cleanup(databaseConfig.Cleanup(t, ctr))
+				}
+			}
+
+			db, err := migrations.New().
+				WithConfig(databaseConfig.Database(t, ctr).Database).
+				WithLogger(logging.NewLogger(logging.Config{Level: logging.LevelDebug})).
+				WithMigrate(true).Run(ctx)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			defer db.CloseDB()
+
+			if err := db.UpsertPrincipal(ctx, principal); err != nil {
+				t.Fatal(err)
+			}
+
+			root := config.Root{
+				Bundles: map[string]*config.Bundle{
+					"bundle-a": {
+						Name: "bundle-a",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+				},
+				Sources: map[string]*config.Source{
+					"source-a": {
+						Name:         "source-a",
+						Requirements: config.Requirements{},
+					},
+				},
+				Database: &config.Database{
+					SQL: &config.SQLDatabase{
+						Driver: "sqlite3",
+						DSN:    database.SQLiteMemoryOnlyDSN,
+					},
+				},
+			}
+			if err := root.Unmarshal(); err != nil {
+				t.Fatalf("failed to unmarshal config: %v", err)
+			}
+
+			tests := []*testCase{
+				// bootstrap environment:
+				newTestCase("load config").LoadConfig(root),
+				newTestCase("list bundles").ListBundles([]*config.Bundle{
+					root.Bundles["bundle-a"],
+				}),
+			}
+
+			for _, test := range tests {
+				t.Run(test.note, func(t *testing.T) {
+					for _, op := range test.operations {
+						op(ctx, t, db)
+					}
+				})
+			}
+
+			t.Run("insert new bundle status", func(t *testing.T) {
+				id, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-1", PhaseSyncBundle, StatusInProgress, "")
+				require.NoError(t, err)
+
+				// Verify the record was inserted correctly
+				status, err := db.GetBundleStatus(ctx, id)
+				require.NoError(t, err)
+				assert.Equal(t, "rev-1", status.Revision)
+				assert.Equal(t, PhaseSyncBundle, status.Phase)
+				assert.Equal(t, StatusInProgress, status.Status)
+				require.NotNil(t, status.ErrorMessage)
+				assert.Equal(t, "", *status.ErrorMessage)
+			})
+		})
+	}
+}
+
+func TestInsertBundleStatusMultipleSameBundleDiffRev(t *testing.T) {
+	ctx := context.Background()
+
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				if databaseConfig.Cleanup != nil {
+					t.Cleanup(databaseConfig.Cleanup(t, ctr))
+				}
+			}
+
+			db, err := migrations.New().
+				WithConfig(databaseConfig.Database(t, ctr).Database).
+				WithLogger(logging.NewLogger(logging.Config{Level: logging.LevelDebug})).
+				WithMigrate(true).Run(ctx)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			defer db.CloseDB()
+
+			if err := db.UpsertPrincipal(ctx, principal); err != nil {
+				t.Fatal(err)
+			}
+
+			root := config.Root{
+				Bundles: map[string]*config.Bundle{
+					"bundle-a": {
+						Name: "bundle-a",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+				},
+				Sources: map[string]*config.Source{
+					"source-a": {
+						Name:         "source-a",
+						Requirements: config.Requirements{},
+					},
+				},
+				Database: &config.Database{
+					SQL: &config.SQLDatabase{
+						Driver: "sqlite3",
+						DSN:    database.SQLiteMemoryOnlyDSN,
+					},
+				},
+			}
+			if err := root.Unmarshal(); err != nil {
+				t.Fatalf("failed to unmarshal config: %v", err)
+			}
+
+			tests := []*testCase{
+				// bootstrap environment:
+				newTestCase("load config").LoadConfig(root),
+				newTestCase("list bundles").ListBundles([]*config.Bundle{
+					root.Bundles["bundle-a"],
+				}),
+			}
+
+			for _, test := range tests {
+				t.Run(test.note, func(t *testing.T) {
+					for _, op := range test.operations {
+						op(ctx, t, db)
+					}
+				})
+			}
+
+			t.Run("insert multiple statuses for same bundle different revisions", func(t *testing.T) {
+				id1, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-1", PhaseSyncBundle, StatusInProgress, "")
+				require.NoError(t, err)
+
+				id2, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-2", PhaseBuildBundle, StatusCompleted, "")
+				require.NoError(t, err)
+
+				assert.NotEqual(t, id1, id2)
+
+				// Both records should exist
+				status1, err := db.GetBundleStatus(ctx, id1)
+				require.NoError(t, err)
+				assert.Equal(t, "rev-1", status1.Revision)
+				assert.Equal(t, PhaseSyncBundle, status1.Phase)
+				assert.Equal(t, StatusInProgress, status1.Status)
+
+				status2, err := db.GetBundleStatus(ctx, id2)
+				require.NoError(t, err)
+				assert.Equal(t, "rev-2", status2.Revision)
+				assert.Equal(t, PhaseBuildBundle, status2.Phase)
+				assert.Equal(t, StatusCompleted, status2.Status)
+			})
+		})
+	}
+}
+
+func TestInsertBundleStatusUpdateExisting(t *testing.T) {
+	ctx := context.Background()
+
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				if databaseConfig.Cleanup != nil {
+					t.Cleanup(databaseConfig.Cleanup(t, ctr))
+				}
+			}
+
+			db, err := migrations.New().
+				WithConfig(databaseConfig.Database(t, ctr).Database).
+				WithLogger(logging.NewLogger(logging.Config{Level: logging.LevelDebug})).
+				WithMigrate(true).Run(ctx)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			defer db.CloseDB()
+
+			if err := db.UpsertPrincipal(ctx, principal); err != nil {
+				t.Fatal(err)
+			}
+
+			root := config.Root{
+				Bundles: map[string]*config.Bundle{
+					"bundle-a": {
+						Name: "bundle-a",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+				},
+				Sources: map[string]*config.Source{
+					"source-a": {
+						Name:         "source-a",
+						Requirements: config.Requirements{},
+					},
+				},
+				Database: &config.Database{
+					SQL: &config.SQLDatabase{
+						Driver: "sqlite3",
+						DSN:    database.SQLiteMemoryOnlyDSN,
+					},
+				},
+			}
+			if err := root.Unmarshal(); err != nil {
+				t.Fatalf("failed to unmarshal config: %v", err)
+			}
+
+			tests := []*testCase{
+				// bootstrap environment:
+				newTestCase("load config").LoadConfig(root),
+				newTestCase("list bundles").ListBundles([]*config.Bundle{
+					root.Bundles["bundle-a"],
+				}),
+			}
+
+			for _, test := range tests {
+				t.Run(test.note, func(t *testing.T) {
+					for _, op := range test.operations {
+						op(ctx, t, db)
+					}
+				})
+			}
+
+			t.Run("insert same tenant+bundle+revision updates existing record", func(t *testing.T) {
+				// Insert first time
+				id1, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-1", PhaseSyncBundle, StatusInProgress, "")
+				require.NoError(t, err)
+
+				// Insert second time with different phase/status - should update existing record
+				id2, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-1", PhaseBuildBundle, StatusInProgress, "")
+				require.NoError(t, err)
+
+				// Should return the same ID
+				assert.Equal(t, id1, id2)
+
+				// Verify the record has the latest phase and status
+				status, err := db.GetBundleStatus(ctx, id1)
+				require.NoError(t, err)
+				assert.Equal(t, PhaseBuildBundle, status.Phase)
+				assert.Equal(t, StatusInProgress, status.Status)
+			})
+		})
+	}
+}
+
+func TestGetBundleStatus(t *testing.T) {
+	ctx := context.Background()
+
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				if databaseConfig.Cleanup != nil {
+					t.Cleanup(databaseConfig.Cleanup(t, ctr))
+				}
+			}
+
+			db, err := migrations.New().
+				WithConfig(databaseConfig.Database(t, ctr).Database).
+				WithLogger(logging.NewLogger(logging.Config{Level: logging.LevelDebug})).
+				WithMigrate(true).Run(ctx)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			defer db.CloseDB()
+
+			if err := db.UpsertPrincipal(ctx, principal); err != nil {
+				t.Fatal(err)
+			}
+
+			root := config.Root{
+				Bundles: map[string]*config.Bundle{
+					"bundle-a": {
+						Name: "bundle-a",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+				},
+				Sources: map[string]*config.Source{
+					"source-a": {
+						Name:         "source-a",
+						Requirements: config.Requirements{},
+					},
+				},
+				Database: &config.Database{
+					SQL: &config.SQLDatabase{
+						Driver: "sqlite3",
+						DSN:    database.SQLiteMemoryOnlyDSN,
+					},
+				},
+			}
+			if err := root.Unmarshal(); err != nil {
+				t.Fatalf("failed to unmarshal config: %v", err)
+			}
+
+			tests := []*testCase{
+				// bootstrap environment:
+				newTestCase("load config").LoadConfig(root),
+				newTestCase("list bundles").ListBundles([]*config.Bundle{
+					root.Bundles["bundle-a"],
+				}),
+			}
+
+			for _, test := range tests {
+				t.Run(test.note, func(t *testing.T) {
+					for _, op := range test.operations {
+						op(ctx, t, db)
+					}
+				})
+			}
+
+			t.Run("get existing status", func(t *testing.T) {
+				id, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-1", PhaseSyncBundle, StatusCompleted, "")
+				require.NoError(t, err)
+
+				status, err := db.GetBundleStatus(ctx, id)
+				require.NoError(t, err)
+				assert.Equal(t, id, int(status.ID))
+				assert.Equal(t, "rev-1", status.Revision)
+				assert.Equal(t, PhaseSyncBundle, status.Phase)
+				assert.Equal(t, StatusCompleted, status.Status)
+				assert.NotZero(t, status.CreatedAt)
+			})
+
+			t.Run("get non-existent status returns ErrNotFound", func(t *testing.T) {
+				_, err := db.GetBundleStatus(ctx, 999999)
+				assert.ErrorIs(t, err, database.ErrNotFound)
+			})
+
+		})
+	}
+}
+
+func TestUpdateBundleStatusError(t *testing.T) {
+	ctx := context.Background()
+
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				if databaseConfig.Cleanup != nil {
+					t.Cleanup(databaseConfig.Cleanup(t, ctr))
+				}
+			}
+
+			db, err := migrations.New().
+				WithConfig(databaseConfig.Database(t, ctr).Database).
+				WithLogger(logging.NewLogger(logging.Config{Level: logging.LevelDebug})).
+				WithMigrate(true).Run(ctx)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			defer db.CloseDB()
+
+			if err := db.UpsertPrincipal(ctx, principal); err != nil {
+				t.Fatal(err)
+			}
+
+			root := config.Root{
+				Bundles: map[string]*config.Bundle{
+					"bundle-a": {
+						Name: "bundle-a",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+				},
+				Sources: map[string]*config.Source{
+					"source-a": {
+						Name:         "source-a",
+						Requirements: config.Requirements{},
+					},
+				},
+				Database: &config.Database{
+					SQL: &config.SQLDatabase{
+						Driver: "sqlite3",
+						DSN:    database.SQLiteMemoryOnlyDSN,
+					},
+				},
+			}
+			if err := root.Unmarshal(); err != nil {
+				t.Fatalf("failed to unmarshal config: %v", err)
+			}
+
+			tests := []*testCase{
+				// bootstrap environment:
+				newTestCase("load config").LoadConfig(root),
+				newTestCase("list bundles").ListBundles([]*config.Bundle{
+					root.Bundles["bundle-a"],
+				}),
+			}
+
+			for _, test := range tests {
+				t.Run(test.note, func(t *testing.T) {
+					for _, op := range test.operations {
+						op(ctx, t, db)
+					}
+				})
+			}
+
+			errMsg := "failed to sync bundle: connection timeout"
+			id, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-1", PhaseSyncBundle, StatusFailed, errMsg)
+			require.NoError(t, err)
+
+			status, err := db.GetBundleStatus(ctx, id)
+			require.NoError(t, err)
+			assert.Equal(t, StatusFailed, status.Status)
+			require.NotNil(t, status.ErrorMessage)
+			assert.Equal(t, errMsg, *status.ErrorMessage)
+		})
+	}
+}
+
+func TestGetLatestBundleStatus(t *testing.T) {
+	ctx := context.Background()
+
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				if databaseConfig.Cleanup != nil {
+					t.Cleanup(databaseConfig.Cleanup(t, ctr))
+				}
+			}
+
+			db, err := migrations.New().
+				WithConfig(databaseConfig.Database(t, ctr).Database).
+				WithLogger(logging.NewLogger(logging.Config{Level: logging.LevelDebug})).
+				WithMigrate(true).Run(ctx)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			defer db.CloseDB()
+
+			if err := db.UpsertPrincipal(ctx, principal); err != nil {
+				t.Fatal(err)
+			}
+
+			root := config.Root{
+				Bundles: map[string]*config.Bundle{
+					"bundle-a": {
+						Name: "bundle-a",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+					"bundle-b": {
+						Name: "bundle-b",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+				},
+				Sources: map[string]*config.Source{
+					"source-a": {
+						Name:         "source-a",
+						Requirements: config.Requirements{},
+					},
+				},
+				Database: &config.Database{
+					SQL: &config.SQLDatabase{
+						Driver: "sqlite3",
+						DSN:    database.SQLiteMemoryOnlyDSN,
+					},
+				},
+			}
+			if err := root.Unmarshal(); err != nil {
+				t.Fatalf("failed to unmarshal config: %v", err)
+			}
+
+			tests := []*testCase{
+				// bootstrap environment:
+				newTestCase("load config").LoadConfig(root),
+				newTestCase("list bundles").ListBundles([]*config.Bundle{
+					root.Bundles["bundle-a"], root.Bundles["bundle-b"],
+				}),
+			}
+
+			for _, test := range tests {
+				t.Run(test.note, func(t *testing.T) {
+					for _, op := range test.operations {
+						op(ctx, t, db)
+					}
+				})
+			}
+
+			t.Run("get latest status", func(t *testing.T) {
+				// Insert multiple statuses with different revisions
+				_, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-1", PhaseSyncBundle, StatusCompleted, "")
+				require.NoError(t, err)
+
+				_, err = db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-2", PhaseBuildBundle, StatusInProgress, "")
+				require.NoError(t, err)
+
+				errMsg := "failed to push bundle"
+				latestID, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-3", PhasePushBundle, StatusFailed, errMsg)
+				require.NoError(t, err)
+
+				// Get latest should return the most recent one
+				latest, err := db.GetLatestBundleStatus(ctx, "admin", tenant, "bundle-a")
+				require.NoError(t, err)
+				assert.Equal(t, latestID, int(latest.ID))
+				assert.Equal(t, "bundle-a", latest.BundleName)
+				assert.Equal(t, "rev-3", latest.Revision)
+				assert.Equal(t, PhasePushBundle, latest.Phase)
+				assert.Equal(t, StatusFailed, latest.Status)
+				require.NotNil(t, latest.ErrorMessage)
+				assert.Equal(t, errMsg, *latest.ErrorMessage)
+			})
+
+			t.Run("get latest for non-existent bundle returns nil", func(t *testing.T) {
+				latest, err := db.GetLatestBundleStatus(ctx, "admin", tenant, "bundle-x")
+				assert.ErrorIs(t, err, database.ErrNotFound)
+				assert.Nil(t, latest)
+			})
+
+			t.Run("get latest returns correct tenant/bundle combination", func(t *testing.T) {
+				_, err := db.UpsertBundleStatus(ctx, tenant, "bundle-b", "rev-1", PhaseBuildBundle, StatusInProgress, "")
+				require.NoError(t, err)
+
+				_, err = db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-1", PhaseSyncBundle, StatusCompleted, "")
+				require.NoError(t, err)
+
+				latestID, err := db.UpsertBundleStatus(ctx, tenant, "bundle-b", "rev-2", PhasePushBundle, StatusInProgress, "")
+				require.NoError(t, err)
+
+				// Get latest for bundle b should return bundle b's record
+				latest, err := db.GetLatestBundleStatus(ctx, "admin", tenant, "bundle-b")
+				require.NoError(t, err)
+				assert.Equal(t, latestID, int(latest.ID))
+				assert.Equal(t, "bundle-b", latest.BundleName)
+				assert.Equal(t, "rev-2", latest.Revision)
+				assert.Equal(t, PhasePushBundle, latest.Phase)
+				assert.Equal(t, StatusInProgress, latest.Status)
+			})
+		})
+	}
+}
+
+func TestListBundleStatuses(t *testing.T) {
+	ctx := context.Background()
+
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				if databaseConfig.Cleanup != nil {
+					t.Cleanup(databaseConfig.Cleanup(t, ctr))
+				}
+			}
+
+			db, err := migrations.New().
+				WithConfig(databaseConfig.Database(t, ctr).Database).
+				WithLogger(logging.NewLogger(logging.Config{Level: logging.LevelDebug})).
+				WithMigrate(true).Run(ctx)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			defer db.CloseDB()
+
+			if err := db.UpsertPrincipal(ctx, principal); err != nil {
+				t.Fatal(err)
+			}
+
+			root := config.Root{
+				Bundles: map[string]*config.Bundle{
+					"bundle-a": {
+						Name: "bundle-a",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+					"bundle-b": {
+						Name: "bundle-b",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+					"bundle-c": {
+						Name: "bundle-c",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+				},
+				Sources: map[string]*config.Source{
+					"source-a": {
+						Name:         "source-a",
+						Requirements: config.Requirements{},
+					},
+				},
+				Database: &config.Database{
+					SQL: &config.SQLDatabase{
+						Driver: "sqlite3",
+						DSN:    database.SQLiteMemoryOnlyDSN,
+					},
+				},
+			}
+			if err := root.Unmarshal(); err != nil {
+				t.Fatalf("failed to unmarshal config: %v", err)
+			}
+
+			tests := []*testCase{
+				// bootstrap environment:
+				newTestCase("load config").LoadConfig(root),
+				newTestCase("list bundles").ListBundles([]*config.Bundle{
+					root.Bundles["bundle-a"], root.Bundles["bundle-b"], root.Bundles["bundle-c"],
+				}),
+			}
+
+			for _, test := range tests {
+				t.Run(test.note, func(t *testing.T) {
+					for _, op := range test.operations {
+						op(ctx, t, db)
+					}
+				})
+			}
+
+			t.Run("get latest status", func(t *testing.T) {
+				t.Run("list all statuses for bundle", func(t *testing.T) {
+					// Insert multiple statuses with different revisions
+					_, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-1", PhaseSyncBundle, StatusCompleted, "")
+					require.NoError(t, err)
+
+					_, err = db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-2", PhaseBuildBundle, StatusCompleted, "")
+					require.NoError(t, err)
+
+					_, err = db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-3", PhasePushBundle, StatusCompleted, "")
+					require.NoError(t, err)
+
+					// List all (empty revision)
+					statuses, err := db.ListBundleStatuses(ctx, "admin", tenant, "bundle-a", "", 0)
+					require.NoError(t, err)
+					assert.Len(t, statuses, 3)
+
+					// Should be ordered by id (newest first)
+					assert.Equal(t, "bundle-a", statuses[0].BundleName)
+					assert.Equal(t, "rev-3", statuses[0].Revision)
+					assert.Equal(t, "rev-2", statuses[1].Revision)
+					assert.Equal(t, "rev-1", statuses[2].Revision)
+				})
+
+				t.Run("list statuses filtered by revision", func(t *testing.T) {
+					// Insert status for specific revision
+					_, err := db.UpsertBundleStatus(ctx, tenant, "bundle-b", "rev-1", PhaseSyncBundle, StatusCompleted, "")
+					require.NoError(t, err)
+
+					_, err = db.UpsertBundleStatus(ctx, tenant, "bundle-b", "rev-2", PhaseBuildBundle, StatusCompleted, "")
+					require.NoError(t, err)
+
+					// List filtered by revision
+					statuses, err := db.ListBundleStatuses(ctx, "admin", tenant, "bundle-a", "rev-1", 0)
+					require.NoError(t, err)
+					assert.Len(t, statuses, 1)
+					assert.Equal(t, "bundle-a", statuses[0].BundleName)
+					assert.Equal(t, "rev-1", statuses[0].Revision)
+				})
+
+				t.Run("list with custom limit", func(t *testing.T) {
+					// Insert 5 statuses with different revisions
+					for i := range 5 {
+						_, err := db.UpsertBundleStatus(ctx, tenant, "bundle-c", fmt.Sprintf("rev-%d", i), PhaseSyncBundle, StatusCompleted, "")
+						require.NoError(t, err)
+					}
+
+					// List with limit of 2
+					statuses, err := db.ListBundleStatuses(ctx, "admin", tenant, "bundle-c", "", 2)
+					require.NoError(t, err)
+					assert.Len(t, statuses, 2)
+					assert.Equal(t, "bundle-c", statuses[0].BundleName)
+					assert.Equal(t, "rev-4", statuses[0].Revision)
+					assert.Equal(t, "rev-3", statuses[1].Revision)
+				})
+
+				t.Run("list for non-existent bundle returns empty", func(t *testing.T) {
+					statuses, err := db.ListBundleStatuses(ctx, "admin", tenant, "bundle-x", "", 0)
+					require.NoError(t, err)
+					assert.Empty(t, statuses)
+				})
+
+			})
+		})
+	}
+}
+
+func TestUpsertBundleStatusRetentionCleanup(t *testing.T) {
+	ctx := context.Background()
+
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				if databaseConfig.Cleanup != nil {
+					t.Cleanup(databaseConfig.Cleanup(t, ctr))
+				}
+			}
+
+			db, err := migrations.New().
+				WithConfig(databaseConfig.Database(t, ctr).Database).
+				WithLogger(logging.NewLogger(logging.Config{Level: logging.LevelDebug})).
+				WithMigrate(true).Run(ctx)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			defer db.CloseDB()
+
+			if err := db.UpsertPrincipal(ctx, principal); err != nil {
+				t.Fatal(err)
+			}
+
+			root := config.Root{
+				Bundles: map[string]*config.Bundle{
+					"bundle-a": {
+						Name: "bundle-a",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+					"bundle-b": {
+						Name: "bundle-b",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+				},
+				Sources: map[string]*config.Source{
+					"source-a": {
+						Name:         "source-a",
+						Requirements: config.Requirements{},
+					},
+				},
+				Database: &config.Database{
+					SQL: &config.SQLDatabase{
+						Driver: "sqlite3",
+						DSN:    database.SQLiteMemoryOnlyDSN,
+					},
+				},
+			}
+			if err := root.Unmarshal(); err != nil {
+				t.Fatalf("failed to unmarshal config: %v", err)
+			}
+
+			tests := []*testCase{
+				newTestCase("load config").LoadConfig(root),
+				newTestCase("list bundles").ListBundles([]*config.Bundle{
+					root.Bundles["bundle-a"], root.Bundles["bundle-b"],
+				}),
+			}
+
+			for _, test := range tests {
+				t.Run(test.note, func(t *testing.T) {
+					for _, op := range test.operations {
+						op(ctx, t, db)
+					}
+				})
+			}
+
+			t.Run("keeps only last MaxBundleStatusRetention records", func(t *testing.T) {
+				totalInserts := maxBundleStatusRetention + 5 // 15 total
+				ids := make([]int, 0, totalInserts)
+
+				for i := range totalInserts {
+					id, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a",
+						fmt.Sprintf("rev-%d", i), PhaseSyncBundle, StatusInProgress, "")
+					require.NoError(t, err)
+					ids = append(ids, id)
+				}
+
+				// List all statuses - should be capped at MaxBundleStatusRetention
+				statuses, err := db.ListBundleStatuses(ctx, "admin", tenant, "bundle-a", "", 0)
+				require.NoError(t, err)
+				assert.Len(t, statuses, maxBundleStatusRetention,
+					"expected only %d records to be retained, got %d", maxBundleStatusRetention, len(statuses))
+
+				// The oldest 5 records should have been deleted
+				for i := range 5 {
+					_, err := db.GetBundleStatus(ctx, ids[i])
+					assert.ErrorIs(t, err, database.ErrNotFound,
+						"expected record with id %d (rev-%d) to be deleted", ids[i], i)
+				}
+
+				// The newest MaxBundleStatusRetention records should still exist
+				for i := 5; i < totalInserts; i++ {
+					status, err := db.GetBundleStatus(ctx, ids[i])
+					require.NoError(t, err,
+						"expected record with id %d (rev-%d) to exist", ids[i], i)
+					assert.Equal(t, fmt.Sprintf("rev-%d", i), status.Revision)
+				}
+			})
+
+			t.Run("no cleanup when under retention limit", func(t *testing.T) {
+				totalInserts := 3
+				ids := make([]int, 0, totalInserts)
+
+				for i := range totalInserts {
+					id, err := db.UpsertBundleStatus(ctx, tenant, "bundle-b",
+						fmt.Sprintf("rev-%d", i), PhaseSyncBundle, StatusCompleted, "")
+					require.NoError(t, err)
+					ids = append(ids, id)
+				}
+
+				// All records should still exist
+				statuses, err := db.ListBundleStatuses(ctx, "admin", tenant, "bundle-b", "", 0)
+				require.NoError(t, err)
+				assert.Len(t, statuses, totalInserts)
+
+				for i := range totalInserts {
+					_, err := db.GetBundleStatus(ctx, ids[i])
+					require.NoError(t, err,
+						"expected record with id %d (rev-%d) to exist", ids[i], i)
+				}
+			})
+
+			t.Run("retention cleanup is scoped per bundle", func(t *testing.T) {
+				// Insert 3 records into bundle-b
+				bundleBIDs := make([]int, 0, 3)
+				for i := range 3 {
+					id, err := db.UpsertBundleStatus(ctx, tenant, "bundle-b",
+						fmt.Sprintf("scope-rev-%d", i), PhaseSyncBundle, StatusCompleted, "")
+					require.NoError(t, err)
+					bundleBIDs = append(bundleBIDs, id)
+				}
+
+				// Insert MaxBundleStatusRetention + 5 records into bundle-a to trigger cleanup
+				for i := range maxBundleStatusRetention + 5 {
+					_, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a",
+						fmt.Sprintf("scope-rev-%d", i), PhaseSyncBundle, StatusInProgress, "")
+					require.NoError(t, err)
+				}
+
+				// bundle-a should have exactly MaxBundleStatusRetention records
+				statuses1, err := db.ListBundleStatuses(ctx, "admin", tenant, "bundle-a", "", 0)
+				require.NoError(t, err)
+				assert.Len(t, statuses1, maxBundleStatusRetention)
+
+				// bundle-b records should be unaffected by bundle-a cleanup
+				for _, id := range bundleBIDs {
+					_, err := db.GetBundleStatus(ctx, id)
+					require.NoError(t, err,
+						"bundle-b record with id %d should not be affected by bundle-a cleanup", id)
+				}
+			})
+		})
+	}
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -291,6 +291,7 @@ func (d *Database) InitDB(ctx context.Context) error {
 					return err
 				}
 				cfg.MultiStatements = true // required for migrations to work
+				cfg.ParseTime = true       // required for scanning time.Time columns
 			} else {
 				cfg = &mysqldriver.Config{
 					User:                    dbUser,
@@ -302,6 +303,7 @@ func (d *Database) InitDB(ctx context.Context) error {
 					AllowOldPasswords:       true,
 					TLSConfig:               tlsConfigName,
 					MultiStatements:         true, // required for migrations
+					ParseTime:               true, // required for scanning time.Time columns
 				}
 
 				_ = cfg.Apply(mysqldriver.BeforeConnect(func(ctx context.Context, config *mysqldriver.Config) error {
@@ -369,6 +371,7 @@ func (d *Database) InitDB(ctx context.Context) error {
 			return err
 		}
 		cfg.MultiStatements = true // required for migrations
+		cfg.ParseTime = true       // required for scanning time.Time columns
 
 		cfg.TLS, err = tlsConfig(ctx, d.config.SQL.Credentials, cfg.TLS)
 		if err != nil {
@@ -1945,20 +1948,20 @@ func (d *Database) lookupID(ctx context.Context, tx *sql.Tx, tenant, table, name
 }
 
 func (d *Database) upsert(ctx context.Context, tx *sql.Tx, tenant, table string, columns []string, primaryKey []string, values ...any) (int, error) {
-	return d.upsertReturning(ctx, true, tx, tenant, table, columns, primaryKey, values...)
+	return d.upsertReturning(ctx, true, false, tx, tenant, table, columns, primaryKey, values...)
 }
 
 func (d *Database) upsertNoID(ctx context.Context, tx *sql.Tx, tenant, table string, columns []string, primaryKey []string, values ...any) error {
-	_, err := d.upsertReturning(ctx, false, tx, tenant, table, columns, primaryKey, values...)
+	_, err := d.upsertReturning(ctx, false, false, tx, tenant, table, columns, primaryKey, values...)
 	return err
 }
 
 func (d *Database) upsertRel(ctx context.Context, tx *sql.Tx, table string, columns []string, primaryKey []string, values ...any) error {
-	_, err := d.upsertReturning(ctx, false, tx, "", table, columns, primaryKey, values...)
+	_, err := d.upsertReturning(ctx, false, false, tx, "", table, columns, primaryKey, values...)
 	return err
 }
 
-func (d *Database) upsertReturning(ctx context.Context, returning bool, tx *sql.Tx, tenant, table string, columns []string, primaryKey []string, values ...any) (int, error) {
+func (d *Database) upsertReturning(ctx context.Context, returning, returningLastInsertID bool, tx *sql.Tx, tenant, table string, columns []string, primaryKey []string, values ...any) (int, error) {
 	valueArgs := d.args(len(columns))
 	if tenant != "" { // not a relation-only table
 		// add tenant
@@ -1991,6 +1994,13 @@ func (d *Database) upsertReturning(ctx context.Context, returning bool, tx *sql.
 
 	case mysql:
 		set := make([]string, 0, len(columns))
+
+		if returning && returningLastInsertID {
+			// Include id = LAST_INSERT_ID(id) so that LastInsertId() returns the
+			// correct row ID even when the row already exists and is updated.
+			set = append(set, "id = LAST_INSERT_ID(id)")
+		}
+
 		for i := range columns {
 			set = append(set, fmt.Sprintf("%s = VALUES(%s)", columns[i], columns[i]))
 		}
@@ -2002,10 +2012,20 @@ func (d *Database) upsertReturning(ctx context.Context, returning bool, tx *sql.
 
 	if returning {
 		if d.kind == mysql { // MySQL has no "... RETURNING (cols)"
-			_, err := tx.ExecContext(ctx, query, values...)
+			result, err := tx.ExecContext(ctx, query, values...)
 			if err != nil {
 				return 0, err
 			}
+
+			if returningLastInsertID {
+				// retrieve the inserted row's ID instead of performing a follow-up SELECT query.
+				id, err := result.LastInsertId()
+				if err != nil {
+					return 0, err
+				}
+				return int(id), nil
+			}
+
 			var id int
 			query = fmt.Sprintf("SELECT %[1]s.id FROM %[1]s JOIN tenants ON tenants.id = %[1]s.tenant_id AND %[1]s.%[2]s = %[3]s", table, primaryKey[0], d.arg(0))
 			return id, tx.QueryRowContext(ctx, query, values[0]).Scan(&id)

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -43,6 +43,7 @@ func Migrations(dialect string) (fs.FS, error) {
 		addBundlesRevision(23, dialect),
 		addDatasourcesCredentialsName(24, dialect),
 		addSourcesGitCredentialsName(25, dialect),
+		addBundlesStatuses(26, dialect),
 	), nil
 }
 

--- a/internal/migrations/migrations_next.go
+++ b/internal/migrations/migrations_next.go
@@ -71,6 +71,38 @@ func addRequirementsOptions(offset int, dialect string) fs.FS {
 	})
 }
 
+func addBundlesStatuses(offset int, dialect string) fs.FS {
+	var kind int
+	switch dialect {
+	case "postgresql":
+		kind = postgres
+	case "mysql":
+		kind = mysql
+	case "sqlite":
+		kind = sqlite
+	case "cockroachdb":
+		kind = cockroachdb
+	}
+
+	tbl := createSQLTable("bundles_statuses").
+		WithIteration("ocp_v2").
+		IntegerPrimaryKeyAutoincrementColumn("id").
+		IntegerNonNullColumn("tenant_id").
+		IntegerNonNullColumn("bundle_id").
+		VarCharNonNullColumn("revision").
+		TextNonNullColumn("phase").
+		TextNonNullColumn("status").
+		TextColumn("error_message").
+		Unique("tenant_id", "bundle_id", "revision").
+		TimestampDefaultCurrentTimeColumn("created_at").
+		ForeignKeyOnDeleteCascade("tenant_id", "tenants(id)").
+		ForeignKeyOnDeleteCascade("bundle_id", "bundles(id)")
+
+	return ocp_fs.MapFS(map[string]string{
+		fmt.Sprintf("%03d_add_bundles_statuses.up.sql", offset): tbl.SQL(kind),
+	})
+}
+
 // NOTE(sr): We create new tables to drop constraints. It's hard to predict constraint names
 // across MySQL and Postgres if they have not been set up at creation time.
 // NOTE(sr): We want this to work, or fail, in one step. So this will all be done in a single migration,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -66,6 +66,8 @@ func (s *Server) Init() *Server {
 	setup("GET", "/v1/bundles/{bundle}", s.v1BundlesGet)
 	setup("PUT", "/v1/bundles/{bundle}", s.v1BundlesPut)
 	setup("DELETE", "/v1/bundles/{bundle}", s.v1BundlesDelete)
+	setup("GET", "/v1/bundles/{bundle}/status/latest", s.v1BundleStatusLatestGet)
+	setup("GET", "/v1/bundles/{bundle}/status", s.v1BundleStatusList)
 
 	setup("GET", "/v1/stacks", s.v1StacksList)
 	setup("GET", "/v1/stacks/{stack}", s.v1StacksGet)
@@ -227,6 +229,61 @@ func (s *Server) v1BundlesDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := types.SourcesDeleteResponseV1{}
+	JSONOK(w, resp, pretty(r))
+}
+
+func (s *Server) v1BundleStatusLatestGet(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	name, err := url.PathUnescape(r.PathValue("bundle"))
+	if err != nil {
+		ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
+		return
+	}
+
+	principal, tenant := s.auth(r)
+	status, err := s.db.GetLatestBundleStatus(ctx, principal, tenant, name)
+	if err != nil {
+		errorAuto(w, err)
+		return
+	}
+
+	resp := types.BundleStatusGetResponseV1{Result: status}
+	JSONOK(w, resp, pretty(r))
+}
+
+func (s *Server) v1BundleStatusList(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	name, err := url.PathUnescape(r.PathValue("bundle"))
+	if err != nil {
+		ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
+		return
+	}
+
+	principal, tenant := s.auth(r)
+
+	q := r.URL.Query()
+	revision := q.Get("revision")
+
+	// Limit validation is skipped at the API layer; the database layer
+	// applies defaults and caps the value
+	var limit int
+	if v := q.Get("limit"); v != "" {
+		limit, err = strconv.Atoi(v)
+		if err != nil {
+			ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
+			return
+		}
+	}
+
+	statuses, err := s.db.ListBundleStatuses(ctx, principal, tenant, name, revision, limit)
+	if err != nil {
+		errorAuto(w, err)
+		return
+	}
+
+	resp := types.BundleStatusListResponseV1{Result: statuses}
 	JSONOK(w, resp, pretty(r))
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/open-policy-agent/opa/v1/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
@@ -1166,4 +1168,202 @@ func (tr *testResponse) ExpectBody(x any) *testResponse {
 		tr.ts.t.Fatal(err)
 	}
 	return tr
+}
+
+func TestV1BundleStatusLatestGet(t *testing.T) {
+	ctx := t.Context()
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				if databaseConfig.Cleanup != nil {
+					t.Cleanup(databaseConfig.Cleanup(t, ctr))
+				}
+			}
+
+			db := initTestDB(t, databaseConfig.Database(t, ctr).Database)
+			ts := initTestServer(t, db)
+			defer ts.Close()
+
+			if err := db.UpsertPrincipal(ctx, principal); err != nil {
+				t.Fatal(err)
+			}
+
+			const ownerKey = "test-owner-key"
+			if err := db.UpsertToken(ctx, "internal", "default", &config.Token{
+				Name:   "testowner",
+				APIKey: ownerKey,
+				Scopes: []config.Scope{{Role: "viewer"}},
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := db.UpsertBundle(ctx, principal.Id, principal.Tenant, &config.Bundle{Name: "bundle1"}); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := db.UpsertBundleStatus(ctx, principal.Tenant, "bundle1", "rev1", "build", "in_progress", ""); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.UpsertBundleStatus(ctx, principal.Tenant, "bundle1", "rev2", "push", "completed", ""); err != nil {
+				t.Fatal(err)
+			}
+
+			t.Run("success", func(t *testing.T) {
+				var resp types.BundleStatusGetResponseV1
+				ts.Request("GET", "/v1/bundles/bundle1/status/latest", "", ownerKey).
+					ExpectStatus(http.StatusOK).
+					ExpectBody(&resp)
+
+				require.NotNil(t, resp.Result)
+				assert.Equal(t, "bundle1", resp.Result.BundleName)
+				assert.Equal(t, "rev2", resp.Result.Revision)
+				assert.Equal(t, "push", resp.Result.Phase)
+				assert.Equal(t, "completed", resp.Result.Status)
+			})
+
+			t.Run("bundle not found", func(t *testing.T) {
+				ts.Request("GET", "/v1/bundles/nonexistent/status/latest", "", ownerKey).
+					ExpectStatus(http.StatusNotFound)
+			})
+
+			t.Run("unauthorized", func(t *testing.T) {
+				ts.Request("GET", "/v1/bundles/bundle1/status/latest", "", "").
+					ExpectStatus(http.StatusUnauthorized)
+			})
+		})
+	}
+}
+
+func TestV1BundleStatusList(t *testing.T) {
+	ctx := t.Context()
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				if databaseConfig.Cleanup != nil {
+					t.Cleanup(databaseConfig.Cleanup(t, ctr))
+				}
+			}
+
+			db := initTestDB(t, databaseConfig.Database(t, ctr).Database)
+			ts := initTestServer(t, db)
+			defer ts.Close()
+
+			if err := db.UpsertPrincipal(ctx, principal); err != nil {
+				t.Fatal(err)
+			}
+
+			const ownerKey = "test-owner-key"
+			if err := db.UpsertToken(ctx, "internal", "default", &config.Token{
+				Name:   "testowner",
+				APIKey: ownerKey,
+				Scopes: []config.Scope{{Role: "viewer"}},
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := db.UpsertBundle(ctx, principal.Id, principal.Tenant, &config.Bundle{Name: "bundle1"}); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := db.UpsertBundleStatus(ctx, principal.Tenant, "bundle1", "rev1", "sync", "in_progress", ""); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.UpsertBundleStatus(ctx, principal.Tenant, "bundle1", "rev1", "build", "in_progress", ""); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.UpsertBundleStatus(ctx, principal.Tenant, "bundle1", "rev2", "push", "failed", "push failed"); err != nil {
+				t.Fatal(err)
+			}
+
+			t.Run("success", func(t *testing.T) {
+				var resp types.BundleStatusListResponseV1
+				ts.Request("GET", "/v1/bundles/bundle1/status", "", ownerKey).
+					ExpectStatus(http.StatusOK).
+					ExpectBody(&resp)
+
+				assert.Len(t, resp.Result, 2) // For a given tenant+bundle+revision combination, only one record exists.
+				assert.Equal(t, "rev2", resp.Result[0].Revision)
+				assert.Equal(t, "rev1", resp.Result[1].Revision)
+			})
+
+			t.Run("filter by revision", func(t *testing.T) {
+				var resp types.BundleStatusListResponseV1
+				ts.Request("GET", "/v1/bundles/bundle1/status?revision=rev1", "", ownerKey).
+					ExpectStatus(http.StatusOK).
+					ExpectBody(&resp)
+
+				assert.Len(t, resp.Result, 1)
+				assert.Equal(t, "rev1", resp.Result[0].Revision)
+				assert.Equal(t, "build", resp.Result[0].Phase)
+				assert.Equal(t, "in_progress", resp.Result[0].Status)
+			})
+
+			t.Run("with limit", func(t *testing.T) {
+				var resp types.BundleStatusListResponseV1
+				ts.Request("GET", "/v1/bundles/bundle1/status?limit=1", "", ownerKey).
+					ExpectStatus(http.StatusOK).
+					ExpectBody(&resp)
+
+				assert.Len(t, resp.Result, 1)
+				assert.Equal(t, "rev2", resp.Result[0].Revision)
+				assert.Equal(t, "push", resp.Result[0].Phase)
+				assert.Equal(t, "failed", resp.Result[0].Status)
+				assert.Equal(t, "push failed", *resp.Result[0].ErrorMessage)
+			})
+
+			t.Run("invalid limit", func(t *testing.T) {
+				ts.Request("GET", "/v1/bundles/bundle1/status?limit=abc", "", ownerKey).
+					ExpectStatus(http.StatusBadRequest)
+			})
+
+			t.Run("empty result for unknown bundle", func(t *testing.T) {
+				var resp types.BundleStatusListResponseV1
+				ts.Request("GET", "/v1/bundles/nonexistent/status", "", ownerKey).
+					ExpectStatus(http.StatusOK).
+					ExpectBody(&resp)
+
+				assert.Empty(t, resp.Result)
+			})
+
+			t.Run("unauthorized", func(t *testing.T) {
+				ts.Request("GET", "/v1/bundles/bundle1/status", "", "").
+					ExpectStatus(http.StatusUnauthorized)
+			})
+
+			const otherPrincipal = "other-internal"
+			const otherTenant = "other-tenant"
+			if _, err := db.DB().ExecContext(ctx, "INSERT INTO tenants (name) VALUES ('"+otherTenant+"')"); err != nil {
+				t.Fatal(err)
+			}
+			p2 := principal
+			p2.Id = otherPrincipal
+			p2.Tenant = otherTenant
+			if err := db.UpsertPrincipal(ctx, p2); err != nil {
+				t.Fatal(err)
+			}
+
+			const otherOwnerKey = "other-test-owner-key"
+			if err := db.UpsertToken(ctx, otherPrincipal, otherTenant, &config.Token{
+				Name:   "othertestowner",
+				APIKey: otherOwnerKey,
+				Scopes: []config.Scope{{Role: "viewer"}},
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			t.Run("other tenant unauthorized", func(t *testing.T) {
+
+				ts.Request("GET", "/v1/bundles/bundle1/status", "", otherOwnerKey).
+					ExpectStatus(http.StatusForbidden)
+			})
+		})
+	}
 }

--- a/internal/server/types/types.go
+++ b/internal/server/types/types.go
@@ -43,6 +43,14 @@ type BundlesGetResponseV1 struct {
 	Result *config.Bundle `json:"result,omitempty"`
 }
 
+type BundleStatusListResponseV1 struct {
+	Result []*config.BundleStatus `json:"result,omitempty"`
+}
+
+type BundleStatusGetResponseV1 struct {
+	Result *config.BundleStatus `json:"result,omitempty"`
+}
+
 type BundlesPutResponseV1 struct{}
 
 type BundlesDeleteResponseV1 struct{}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -214,6 +214,10 @@ func (b *Builder) WithRevisionFunc(fn func(fs.FS) (string, error)) *Builder {
 	return b
 }
 
+func (b *Builder) Revision() string {
+	return b.revision
+}
+
 type PackageConflictErr struct {
 	Requirement *Source
 	Package     *ast.Package

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -186,6 +186,21 @@ func (o Options) Empty() bool {
 	return o == Options{}
 }
 
+// BundleStatus represents the build status of a bundle.
+type BundleStatus struct {
+	ID           int64     `json:"-"`
+	TenantID     int64     `json:"-"`
+	BundleID     int64     `json:"-"`
+	BundleName   string    `json:"bundle_name"`
+	Revision     string    `json:"revision,omitempty"`
+	Phase        string    `json:"phase"`
+	Status       string    `json:"status"`
+	ErrorMessage *string   `json:"error_message,omitempty"`
+	CreatedAt    time.Time `json:"created_at"`
+
+	_ struct{} `additionalProperties:"false"`
+}
+
 // Bundle defines the configuration for an OPA Control Plane Bundle.
 type Bundle struct {
 	Name          string        `json:"name"`

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -75,6 +75,7 @@ type Report struct {
 }
 
 type BuildState int
+type BuildPhase int
 
 const (
 	BuildStateInternalError BuildState = iota
@@ -84,6 +85,11 @@ const (
 	BuildStateTransformFailed
 	BuildStateBuildFailed
 	BuildStatePushFailed
+)
+
+const (
+	BuildPhaseBuild BuildPhase = iota
+	BuildPhasePush
 )
 
 func (s BuildState) String() string {
@@ -102,6 +108,17 @@ func (s BuildState) String() string {
 		return "PUSH_FAILED"
 	case BuildStateInternalError:
 		fallthrough
+	default:
+		return "INTERNAL_ERROR"
+	}
+}
+
+func (s BuildPhase) String() string {
+	switch s {
+	case BuildPhaseBuild:
+		return "BUILD"
+	case BuildPhasePush:
+		return "PUSH"
 	default:
 		return "INTERNAL_ERROR"
 	}
@@ -439,7 +456,9 @@ func (s *Service) launchWorkers(ctx context.Context) {
 				WithSources(sources).
 				WithSynchronizers(syncs).
 				WithInterval(b.Interval).
-				WithSingleShot(s.singleShot)
+				WithSingleShot(s.singleShot).
+				WithDatabase(s.Database()).
+				WithTenant(defaultTenant)
 
 			if s.storage != nil {
 				w.WithStorage(s.storage)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -10,11 +10,13 @@ import (
 	"path/filepath"
 	"testing"
 	"text/template"
+	"time"
 
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	"github.com/open-policy-agent/opa-control-plane/internal/logging"
 	"github.com/open-policy-agent/opa-control-plane/pkg/service"
 	pkgsync "github.com/open-policy-agent/opa-control-plane/pkg/sync"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestUnconfiguredSecretHandling(t *testing.T) {
@@ -124,6 +126,204 @@ func TestRequirementsWithOverrides(t *testing.T) {
 	}
 	if string(foo) != initialContent {
 		t.Fatal("unexpected file content")
+	}
+}
+
+func TestBundleStatusPushSuccess(t *testing.T) {
+
+	tempDir := t.TempDir()
+
+	tmpl := `{
+		bundles: {
+			test_bundle: {
+				object_storage: {
+					filesystem: {
+						path: "{{ printf "%s/%s" .Path "bundles.tar.gz" }}",
+					}
+				},
+				requirements: [
+					{source: test_src, git: {commit: "{{ .GitHash }}"}},
+				],
+				revision: "{{ .Revision }}",
+			},
+		},
+		sources: {
+			test_src: {
+				git: {
+					repo: "{{ printf "%s/%s" .Path "remotegit" }}",
+					reference: refs/heads/master,
+				},
+			},
+		},
+	}`
+
+	const initialContent = `package foo
+
+		p := 7`
+
+	h := writeGitRepo(t, filepath.Join(tempDir, "remotegit"), map[string]string{
+		"foo.rego": initialContent,
+	}, nil)
+
+	writeGitFiles(t, filepath.Join(tempDir, "remotegit"), map[string]string{
+		"foo.rego": `package foo
+
+		p := 8`,
+	})
+
+	bs := render(t, tmpl, struct {
+		Path     string
+		GitHash  string
+		Revision string
+	}{
+		Path:     tempDir,
+		GitHash:  h.String(),
+		Revision: "time.now_ns()",
+	})
+
+	log := logging.NewLogger(logging.Config{Level: logging.LevelDebug})
+
+	cfg, err := config.Parse(bs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc := service.New().
+		WithConfig(cfg).
+		WithPersistenceDir(filepath.Join(tempDir, "data")).
+		WithMigrateDB(true).
+		WithLogger(log)
+
+	var g errgroup.Group
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	stopped := make(chan struct{})
+	g.Go(func() error {
+		defer close(stopped)
+		return svc.Run(ctx)
+	})
+
+	time.Sleep(time.Millisecond * 500)
+
+	status, err := svc.Database().GetLatestBundleStatus(t.Context(), "internal", "default", "test_bundle")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status == nil {
+		t.Fatal("expected status to be present")
+	}
+
+	cancel()
+	<-stopped
+
+	if status.Phase != service.BuildPhasePush.String() {
+		t.Fatalf("expected bundle phase %v but got %v", service.BuildPhasePush.String(), status.Phase)
+	}
+
+	if status.Status != service.BuildStateSuccess.String() {
+		t.Fatalf("expected bundle status %v but got %v", service.BuildStateSuccess.String(), status.Status)
+	}
+}
+
+func TestBundleStatusPushFailed(t *testing.T) {
+
+	tempDir := t.TempDir()
+
+	tmpl := `{
+		bundles: {
+			test_bundle: {
+				object_storage: {
+					aws: {
+						bucket: "{{ printf "%s" "no_such_bucket" }}",
+                        key: "{{ printf "%s" "no_such_key" }}",
+                        region: "{{ printf "%s" "no_such_region" }}",
+					}
+				},
+				requirements: [
+					{source: test_src, git: {commit: "{{ .GitHash }}"}},
+				],
+				revision: "{{ .Revision }}",
+			},
+		},
+		sources: {
+			test_src: {
+				git: {
+					repo: "{{ printf "%s/%s" .Path "remotegit" }}",
+					reference: refs/heads/master,
+				},
+			},
+		},
+	}`
+
+	const initialContent = `package foo
+
+		p := 7`
+
+	h := writeGitRepo(t, filepath.Join(tempDir, "remotegit"), map[string]string{
+		"foo.rego": initialContent,
+	}, nil)
+
+	writeGitFiles(t, filepath.Join(tempDir, "remotegit"), map[string]string{
+		"foo.rego": `package foo
+
+		p := 8`,
+	})
+
+	bs := render(t, tmpl, struct {
+		Path     string
+		GitHash  string
+		Revision string
+	}{
+		Path:     tempDir,
+		GitHash:  h.String(),
+		Revision: "time.now_ns()",
+	})
+
+	log := logging.NewLogger(logging.Config{Level: logging.LevelDebug})
+
+	cfg, err := config.Parse(bs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc := service.New().
+		WithConfig(cfg).
+		WithPersistenceDir(filepath.Join(tempDir, "data")).
+		WithMigrateDB(true).
+		WithLogger(log)
+
+	var g errgroup.Group
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	stopped := make(chan struct{})
+	g.Go(func() error {
+		defer close(stopped)
+		return svc.Run(ctx)
+	})
+
+	time.Sleep(time.Millisecond * 500)
+
+	status, err := svc.Database().GetLatestBundleStatus(t.Context(), "internal", "default", "test_bundle")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status == nil {
+		t.Fatal("expected status to be present")
+	}
+
+	cancel()
+	<-stopped
+
+	if status.Phase != service.BuildPhasePush.String() {
+		t.Fatalf("expected bundle phase %v but got %v", service.BuildPhasePush.String(), status.Phase)
+	}
+
+	if status.Status != service.BuildStatePushFailed.String() {
+		t.Fatalf("expected bundle status %v but got %v", service.BuildStatePushFailed.String(), status.Status)
 	}
 }
 

--- a/pkg/service/worker.go
+++ b/pkg/service/worker.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
+	"github.com/open-policy-agent/opa-control-plane/internal/database"
 	ocp_fs "github.com/open-policy-agent/opa-control-plane/internal/fs"
 	"github.com/open-policy-agent/opa-control-plane/internal/logging"
 	"github.com/open-policy-agent/opa-control-plane/internal/metrics"
@@ -42,6 +43,8 @@ type BundleWorker struct {
 	bar           *progress.Bar
 	status        Status
 	interval      time.Duration
+	database      *database.Database
+	tenant        string
 }
 
 type Synchronizer interface {
@@ -91,6 +94,16 @@ func (worker *BundleWorker) WithSingleShot(singleShot bool) *BundleWorker {
 
 func (worker *BundleWorker) WithInterval(d config.Duration) *BundleWorker {
 	worker.interval = cmp.Or(time.Duration(d), defaultInterval)
+	return worker
+}
+
+func (worker *BundleWorker) WithDatabase(database *database.Database) *BundleWorker {
+	worker.database = database
+	return worker
+}
+
+func (worker *BundleWorker) WithTenant(tenant string) *BundleWorker {
+	worker.tenant = tenant
 	return worker
 }
 
@@ -203,7 +216,21 @@ func (w *BundleWorker) Execute(ctx context.Context) time.Time {
 
 	if err := b.Build(ctx); err != nil {
 		w.log.Warnf("failed to build a bundle %q: %v", w.bundleConfig.Name, err)
+
+		if b.Revision() != "" {
+			_, err := w.database.UpsertBundleStatus(ctx, w.tenant, w.bundleConfig.Name, b.Revision(), BuildPhaseBuild.String(), BuildStateBuildFailed.String(), err.Error())
+			if err != nil {
+				w.log.Warnf("failed to track bundle build state %q: %v", w.bundleConfig.Name, err)
+			}
+		}
 		return w.report(ctx, BuildStateBuildFailed, startTime, err)
+	}
+
+	if b.Revision() != "" {
+		_, err := w.database.UpsertBundleStatus(ctx, w.tenant, w.bundleConfig.Name, b.Revision(), BuildPhaseBuild.String(), BuildStateSuccess.String(), "")
+		if err != nil {
+			w.log.Warnf("failed to track bundle build state %q: %v", w.bundleConfig.Name, err)
+		}
 	}
 
 	if w.storage != nil {
@@ -214,10 +241,24 @@ func (w *BundleWorker) Execute(ctx context.Context) time.Time {
 				return w.report(ctx, BuildStateSuccess, startTime, nil)
 			}
 			w.log.Warnf("failed to upload bundle %q: %v", w.bundleConfig.Name, err)
+
+			if b.Revision() != "" {
+				_, err := w.database.UpsertBundleStatus(ctx, w.tenant, w.bundleConfig.Name, b.Revision(), BuildPhasePush.String(), BuildStatePushFailed.String(), err.Error())
+				if err != nil {
+					w.log.Warnf("failed to track bundle upload state %q: %v", w.bundleConfig.Name, err)
+				}
+			}
 			return w.report(ctx, BuildStatePushFailed, startTime, err)
 		}
 
 		w.log.Debugf("Bundle %q built and uploaded.", w.bundleConfig.Name)
+
+		if b.Revision() != "" {
+			_, err := w.database.UpsertBundleStatus(ctx, w.tenant, w.bundleConfig.Name, b.Revision(), BuildPhasePush.String(), BuildStateSuccess.String(), "")
+			if err != nil {
+				w.log.Warnf("failed to track bundle upload state %q: %v", w.bundleConfig.Name, err)
+			}
+		}
 		return w.report(ctx, BuildStateSuccess, startTime, nil)
 	}
 


### PR DESCRIPTION
This change adds support for tracking the status of a bundle
through the build and push phases. The sync phase
is not tracked as we need a bundle revision to keep
track of a tenant+bundle+revision combo.