### PR TITLE
pkg/service: add WithAuthorizer and expose logging package

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -37,6 +37,14 @@ func NewLogger(config Config) *Logger {
 	}
 }
 
+// FromSlog wraps a standard *slog.Logger into an internal Logger.
+func FromSlog(l *slog.Logger) *Logger {
+	if l == nil {
+		return nil
+	}
+	return &Logger{l: l}
+}
+
 func (l *Logger) Debug(msg string, args ...any) {
 	if l == nil || !l.l.Enabled(context.Background(), slog.LevelDebug) {
 		return

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	"github.com/open-policy-agent/opa-control-plane/internal/database"
 	"github.com/open-policy-agent/opa-control-plane/internal/logging"
+	ext_authz "github.com/open-policy-agent/opa-control-plane/pkg/authz"
 )
 
 const (
@@ -46,9 +47,10 @@ func Migrations(dialect string) (fs.FS, error) {
 }
 
 type Migrator struct {
-	config  *config.Database
-	log     *logging.Logger
-	migrate bool
+	config     *config.Database
+	log        *logging.Logger
+	migrate    bool
+	authorizer ext_authz.Authorizer
 }
 
 func New() *Migrator {
@@ -72,8 +74,16 @@ func (m *Migrator) WithLogger(log *logging.Logger) *Migrator {
 	return m
 }
 
+func (m *Migrator) WithAuthorizer(a ext_authz.Authorizer) *Migrator {
+	m.authorizer = a
+	return m
+}
+
 func (m *Migrator) Run(ctx context.Context) (*database.Database, error) {
 	db := database.New().WithConfig(m.config).WithLogger(m.log)
+	if m.authorizer != nil {
+		db = db.WithAuthorizer(m.authorizer)
+	}
 	if err := db.InitDB(ctx); err != nil {
 		return nil, fmt.Errorf("migrate: %w", err)
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"maps"
 	"path"
 	"path/filepath"
@@ -32,6 +33,7 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/progress"
 	"github.com/open-policy-agent/opa-control-plane/internal/s3"
 	"github.com/open-policy-agent/opa-control-plane/internal/sqlsync"
+	ext_authz "github.com/open-policy-agent/opa-control-plane/pkg/authz"
 	"github.com/open-policy-agent/opa-control-plane/pkg/builder"
 	ext_os "github.com/open-policy-agent/opa-control-plane/pkg/objectstorage"
 )
@@ -65,6 +67,7 @@ type Service struct {
 	initialized    bool
 	storage        ext_os.ObjectStorage
 	secretFactory  pkgsync.SecretProviderFactory
+	authorizer     ext_authz.Authorizer
 }
 
 type Report struct {
@@ -124,6 +127,12 @@ func (s *Service) WithPersistenceDir(d string) *Service {
 	return s
 }
 
+func (s *Service) WithAuthorizer(a ext_authz.Authorizer) *Service {
+	s.authorizer = a
+	s.database = *s.database.WithAuthorizer(a)
+	return s
+}
+
 func (s *Service) WithConfig(config *config.Root) *Service {
 	s.config = config
 	s.database = *s.database.WithConfig(config.Database)
@@ -153,6 +162,14 @@ func (s *Service) Database() *database.Database {
 func (s *Service) WithLogger(logger *logging.Logger) *Service {
 	s.log = logger
 	s.database = *s.database.WithLogger(logger)
+	return s
+}
+
+// WithSlogLogger sets the service logger from a standard *slog.Logger.
+func (s *Service) WithSlogLogger(logger *slog.Logger) *Service {
+	l := logging.FromSlog(logger)
+	s.log = l
+	s.database = *s.database.WithLogger(l)
 	return s
 }
 
@@ -261,6 +278,7 @@ func (s *Service) initDB(ctx context.Context) error {
 		WithConfig(s.config.Database).
 		WithLogger(s.log).
 		WithMigrate(s.migrateDB).
+		WithAuthorizer(s.authorizer).
 		Run(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Add WithAuthorizer to Service so external consumers can override the default OPAuthorizer (e.g. with a bypass authorizer). The authorizer is persisted across initDB since migrations.Run() creates a new database instance that resets to the default authorizer.

Also expose the internal logging package via pkg/logging so external consumers can create loggers for WithLogger without importing internal packages.