### PR TITLE
Apply formatting to refactored modules during bundle build

### DIFF
--- a/e2e/cli/build_builtin_mounts.txtar
+++ b/e2e/cli/build_builtin_mounts.txtar
@@ -33,3 +33,25 @@ sources:
 {"revision":"","roots":["imported/newinput"],"rego_version":0}
 -- exp/transform.rego --
 package imported.newinput
+
+# This package is used to transform the input request from
+# an existing schema to the Styra-supported entz schema.
+# This is done by creating a rule here named "newinput" that
+# translates the input to the Styra schema
+#
+# import future.keywords
+#
+# decoded_jwt := io.jwt.decode(input.jwt)
+#
+# jwt_context := {
+#     "jwt": {
+#         "header": decoded_jwt[0],
+#         "payload": decoded_jwt[1],
+#         "signature": decoded_jwt[2],
+#         "raw": input.jwt
+#     }
+# }
+#
+# newinput = obj {
+#     obj = object.union(input, {"context": jwt_context})
+# } else = input

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -22,6 +22,7 @@ import (
 	"github.com/open-policy-agent/opa/bundle"  // nolint:staticcheck
 	"github.com/open-policy-agent/opa/compile" // nolint:staticcheck
 	"github.com/open-policy-agent/opa/rego"    // nolint:staticcheck
+	"github.com/open-policy-agent/opa/v1/format"
 	"github.com/open-policy-agent/opa/v1/refactor"
 	"github.com/open-policy-agent/opa/v1/topdown"
 
@@ -642,7 +643,11 @@ func extractAndTransformRego(fsys fs.FS, mnts []mount) (fs.FS, error) {
 
 	rendered := make(map[string]string, len(modules))
 	for p, m := range modules {
-		rendered[p] = m.String()
+		r, err := format.Ast(m)
+		if err != nil {
+			return nil, fmt.Errorf("failed to format module %s, %w", p, err)
+		}
+		rendered[p] = string(r)
 	}
 
 	return ocp_fs.MapFS(rendered), nil

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -648,7 +648,6 @@ func extractAndTransformRego(fsys fs.FS, mnts []mount) (fs.FS, error) {
 			return nil, fmt.Errorf("failed to format module %s, %w", p, err)
 		}
 		rendered[p] = string(r)
-		//rendered[p] = m.String()
 	}
 
 	return ocp_fs.MapFS(rendered), nil

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -21,8 +21,8 @@ import (
 	"github.com/open-policy-agent/opa/ast"     // nolint:staticcheck
 	"github.com/open-policy-agent/opa/bundle"  // nolint:staticcheck
 	"github.com/open-policy-agent/opa/compile" // nolint:staticcheck
+	"github.com/open-policy-agent/opa/format"  // nolint:staticcheck
 	"github.com/open-policy-agent/opa/rego"    // nolint:staticcheck
-	"github.com/open-policy-agent/opa/v1/format"
 	"github.com/open-policy-agent/opa/v1/refactor"
 	"github.com/open-policy-agent/opa/v1/topdown"
 
@@ -648,6 +648,7 @@ func extractAndTransformRego(fsys fs.FS, mnts []mount) (fs.FS, error) {
 			return nil, fmt.Errorf("failed to format module %s, %w", p, err)
 		}
 		rendered[p] = string(r)
+		//rendered[p] = m.String()
 	}
 
 	return ocp_fs.MapFS(rendered), nil

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -439,6 +439,38 @@ func TestBuilder(t *testing.T) {
 			expRoots: []string{"authz", "x"},
 		},
 		{
+			// Note: Regression test for proper formatted modules after refactoring move
+			note: "requirements mounts: formatting regression test",
+			sources: []sourceMock{
+				{
+					name: "system",
+					files: map[string]string{
+						"x.rego": `package x
+						p := data.authz.p`,
+					},
+					requirements: []reqMock{{
+						name: "lib1",
+						path: "data.lib1",
+					}},
+				},
+				{
+					name: "lib1",
+					files: map[string]string{
+						"lib1.rego": `package lib1.authz
+						p := [(to_number(x) / 50) | x := "100"]`,
+					},
+				},
+			},
+			excluded: []string{"x/z/data.json"},
+			exp: map[string]string{
+				"/system/x.rego": `package x
+				p := data.authz.p`,
+				"/lib1/lib1.rego": ` package authz
+				p := [(to_number(x) / 50) | x := "100"]`, // formatting retains parenthesis wrapping comprehension term
+			},
+			expRoots: []string{"authz", "x"},
+		},
+		{
 			note: "package conflict: prefix",
 			sources: []sourceMock{
 				{


### PR DESCRIPTION
instead of using `.String()` function on `ast.Module` which isn't guaranteed to always generate proper Rego.