### PR TITLE
database: add UpsertTenantWithPrincipal to create tenant and principal atomically

### DIFF
--- a/internal/database/principal.go
+++ b/internal/database/principal.go
@@ -26,6 +26,27 @@ func (db *Database) UpsertPrincipalTx(ctx context.Context, tx *sql.Tx, principal
 	return nil
 }
 
+// UpsertTenantWithPrincipal creates a tenant and its associated principal in a
+// single transaction. Both inserts are idempotent.
+func (db *Database) UpsertTenantWithPrincipal(ctx context.Context, tenantName, principalID, role string) error {
+	return tx1(ctx, db, func(tx *sql.Tx) error {
+		if err := db.upsertTenantTx(ctx, tx, tenantName); err != nil {
+			return err
+		}
+		if err := db.UpsertPrincipalTx(ctx, tx, Principal{Id: principalID, Role: role, Tenant: tenantName}); err != nil {
+			return fmt.Errorf("failed to upsert principal %q for tenant %q: %w", principalID, tenantName, err)
+		}
+		return nil
+	})
+}
+
+func (db *Database) upsertTenantTx(ctx context.Context, tx *sql.Tx, tenantName string) error {
+	if err := db.upsertRel(ctx, tx, "tenants", []string{"name"}, []string{"name"}, tenantName); err != nil {
+		return fmt.Errorf("failed to upsert tenant %q: %w", tenantName, err)
+	}
+	return nil
+}
+
 func (db *Database) GetPrincipalID(ctx context.Context, apiKey string) (string, error) {
 	query := `SELECT principals.id FROM principals JOIN tokens ON tokens.name = principals.id WHERE tokens.api_key = ` + db.arg(0)
 	row := db.db.QueryRowContext(ctx, query, apiKey)

--- a/internal/database/principal_test.go
+++ b/internal/database/principal_test.go
@@ -8,9 +8,57 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/database"
 	"github.com/open-policy-agent/opa-control-plane/internal/migrations"
 	"github.com/open-policy-agent/opa-control-plane/internal/test/dbs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
 )
+
+func TestUpsertTenantWithPrincipal(t *testing.T) {
+	ctx := t.Context()
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				t.Cleanup(databaseConfig.Cleanup(t, ctr))
+			}
+
+			db, err := migrations.New().WithConfig(databaseConfig.Database(t, ctr).Database).WithMigrate(true).Run(ctx)
+			require.NoError(t, err)
+
+			t.Run("creates tenant and principal", func(t *testing.T) {
+				err := db.UpsertTenantWithPrincipal(ctx, "myapp", "internal:myapp", "administrator")
+				require.NoError(t, err)
+
+				var tenantName string
+				err = db.DB().QueryRowContext(ctx, "SELECT name FROM tenants WHERE name = 'myapp'").Scan(&tenantName)
+				require.NoError(t, err)
+				assert.Equal(t, "myapp", tenantName)
+
+				var principalID string
+				err = db.DB().QueryRowContext(ctx,
+					"SELECT id FROM principals WHERE id = 'internal:myapp'",
+				).Scan(&principalID)
+				require.NoError(t, err)
+				assert.Equal(t, "internal:myapp", principalID)
+			})
+
+			t.Run("idempotent on repeated calls", func(t *testing.T) {
+				err := db.UpsertTenantWithPrincipal(ctx, "myapp2", "internal:myapp2", "administrator")
+				require.NoError(t, err)
+				err = db.UpsertTenantWithPrincipal(ctx, "myapp2", "internal:myapp2", "administrator")
+				require.NoError(t, err)
+
+				var count int
+				err = db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM tenants WHERE name = 'myapp2'").Scan(&count)
+				require.NoError(t, err)
+				assert.Equal(t, 1, count)
+			})
+		})
+	}
+}
 
 func TestCascadingDeletesForPrincipalsAndResourcePermissions(t *testing.T) {
 	ctx := t.Context()

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -219,3 +219,9 @@ func (d *Database) UpsertPrincipal(ctx context.Context, id, role, tenant string)
 		Tenant: tenant,
 	})
 }
+
+// UpsertTenantWithPrincipal creates a tenant and its associated principal in a
+// single transaction. Both inserts are idempotent.
+func (d *Database) UpsertTenantWithPrincipal(ctx context.Context, tenantName, principalID, role string) error {
+	return d.db.UpsertTenantWithPrincipal(ctx, tenantName, principalID, role)
+}


### PR DESCRIPTION
  - Adds `UpsertTenantWithPrincipal(ctx, tenantName, principalID, role string) error` to both `internal/database` and `pkg/database`
  - Wraps a tenant insert and a principal insert in a single transaction — both operations are idempotent (`ON CONFLICT DO NOTHING` / `DO UPDATE`)
  - Extracts `upsertTenantTx` helper following the existing `UpsertPrincipalTx` pattern

@srenatus 