### PR TITLE
service: return error when revision exceeds 255 characters

### DIFF
--- a/pkg/service/revision.go
+++ b/pkg/service/revision.go
@@ -13,6 +13,10 @@ import (
 	"github.com/open-policy-agent/opa/v1/rego"
 )
 
+// MaxRevisionLength is the maximum allowed length for a resolved revision string.
+// This matches the VARCHAR(255) column size used for revisions in MySQL and PostgreSQL.
+const MaxRevisionLength = 255
+
 // ReferencedSource represents a source that is referenced in the revision expression
 type ReferencedSource struct {
 	SourceName string
@@ -99,6 +103,11 @@ func resolveRevision(ctx context.Context, revision string, sourceMetadata map[st
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve revision: %w", err)
 	}
+
+	if len(result) > MaxRevisionLength {
+		return "", fmt.Errorf("resolved revision exceeds maximum length of %d characters (got %d)", MaxRevisionLength, len(result))
+	}
+
 	return result, nil
 }
 

--- a/pkg/service/revision_test.go
+++ b/pkg/service/revision_test.go
@@ -474,6 +474,16 @@ func TestResolveRevision(t *testing.T) {
 			wantErr:         true,
 			wantErrContains: "undefined ref",
 		},
+		{
+			name:     "revision exceeding max length",
+			revision: `$"{input.sources.policies.git.commit}-{input.sources.data.sql.hash}"`,
+			sourceMetadata: map[string]map[string]any{
+				"policies": {"git": map[string]any{"commit": strings.Repeat("a", 200)}},
+				"data":     {"sql": map[string]any{"hash": strings.Repeat("b", 200)}},
+			},
+			wantErr:         true,
+			wantErrContains: "resolved revision exceeds maximum length",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #334. At least now, we'll return an informative error and not some cryptic database error.