### PR TITLE
Refactor ObjectStorage's Upload to use options struct

### DIFF
--- a/internal/s3/s3.go
+++ b/internal/s3/s3.go
@@ -206,7 +206,7 @@ func (e *Error) Error() string {
 // Upload uploads a file to the S3-compatible storage. It computes the SHA256 digest of the file and records that to the object metadata.
 // Relying on object ETag is not if the object is encrypted with SSE-C or SSE-KMS, as the ETag will not be the MD5 hash of the object.
 // With (part) checksums, only parallellizable, less reliable checksums (CRCs) are supported.
-func (s *AmazonS3) Upload(ctx context.Context, body io.ReadSeeker, _ string, revision string, _ int64) error {
+func (s *AmazonS3) Upload(ctx context.Context, body io.ReadSeeker, opts ext_os.UploadOptions) error {
 
 	digest, equal, err := s.check(ctx, body)
 	if err != nil {
@@ -224,8 +224,8 @@ func (s *AmazonS3) Upload(ctx context.Context, body io.ReadSeeker, _ string, rev
 	metadata := map[string]string{
 		"sha256": hex.EncodeToString(digest),
 	}
-	if revision != "" {
-		metadata["revision"] = revision
+	if opts.Revision != "" {
+		metadata["revision"] = opts.Revision
 	}
 
 	_, err = s.client.PutObject(ctx, &s3.PutObjectInput{
@@ -278,13 +278,13 @@ func (s *AmazonS3) check(ctx context.Context, body io.Reader) ([]byte, bool, err
 	return digest, output.Metadata["sha256"] == hex.EncodeToString(digest), nil
 }
 
-func (s *GCPCloudStorage) Upload(ctx context.Context, body io.ReadSeeker, _ string, revision string, _ int64) error {
+func (s *GCPCloudStorage) Upload(ctx context.Context, body io.ReadSeeker, opts ext_os.UploadOptions) error {
 	w := s.client.Bucket(s.bucket).Object(s.object).NewWriter(ctx)
 	if w.Metadata == nil {
 		w.Metadata = make(map[string]string)
 	}
-	if revision != "" {
-		w.Metadata["revision"] = revision
+	if opts.Revision != "" {
+		w.Metadata["revision"] = opts.Revision
 	}
 	if _, err := io.Copy(w, body); err != nil {
 		return err
@@ -297,14 +297,15 @@ func (*GCPCloudStorage) Download(context.Context) (io.Reader, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (s *AzureBlobStorage) Upload(ctx context.Context, body io.ReadSeeker, _ string, revision string, _ int64) error {
-	opts := &azblob.UploadStreamOptions{}
-	if revision != "" {
-		opts.Metadata = map[string]*string{
+func (s *AzureBlobStorage) Upload(ctx context.Context, body io.ReadSeeker, opts ext_os.UploadOptions) error {
+	uploadOpts := &azblob.UploadStreamOptions{}
+	if opts.Revision != "" {
+		revision := opts.Revision
+		uploadOpts.Metadata = map[string]*string{
 			"revision": &revision,
 		}
 	}
-	_, err := s.client.UploadStream(ctx, s.container, s.path, body, opts)
+	_, err := s.client.UploadStream(ctx, s.container, s.path, body, uploadOpts)
 	return err
 }
 
@@ -312,7 +313,7 @@ func (*AzureBlobStorage) Download(context.Context) (io.Reader, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (s *FileSystemStorage) Upload(ctx context.Context, body io.ReadSeeker, _ string, _ string, _ int64) error {
+func (s *FileSystemStorage) Upload(ctx context.Context, body io.ReadSeeker, _ ext_os.UploadOptions) error {
 	digest, equal, err := s.check(ctx, body)
 	if err != nil {
 		return err

--- a/internal/s3/s3_test.go
+++ b/internal/s3/s3_test.go
@@ -52,7 +52,7 @@ func TestS3(t *testing.T) {
 	}
 
 	bundle := bytes.NewReader([]byte("bundle content"))
-	err = storage.Upload(ctx, bundle, "testbundle", "", bundle.Size())
+	err = storage.Upload(ctx, bundle, ext_os.UploadOptions{})
 	if err != nil {
 		t.Fatalf("expected no error while uploading bundle: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestS3WithRevision(t *testing.T) {
 	bundleContent := []byte("bundle content with revision")
 	bundle := bytes.NewReader(bundleContent)
 	revision := "v1.2.3"
-	err = storage.Upload(ctx, bundle, "testbundle", revision, bundle.Size())
+	err = storage.Upload(ctx, bundle, ext_os.UploadOptions{Revision: revision})
 	if err != nil {
 		t.Fatalf("expected no error while uploading bundle: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestS3WithoutRevision(t *testing.T) {
 	// Upload a bundle without a revision
 	bundleContent := []byte("bundle content without revision")
 	bundle := bytes.NewReader(bundleContent)
-	err = storage.Upload(ctx, bundle, "testbundle", "", bundle.Size())
+	err = storage.Upload(ctx, bundle, ext_os.UploadOptions{})
 	if err != nil {
 		t.Fatalf("expected no error while uploading bundle: %v", err)
 	}
@@ -246,19 +246,19 @@ func TestS3NotModified(t *testing.T) {
 
 	// First upload should succeed.
 	r := bytes.NewReader(content)
-	if err := storage.Upload(ctx, r, "b", "", r.Size()); err != nil {
+	if err := storage.Upload(ctx, r, ext_os.UploadOptions{}); err != nil {
 		t.Fatalf("first upload: %v", err)
 	}
 
 	// Second upload with identical content should return ErrNotModified.
 	r = bytes.NewReader(content)
-	if err := storage.Upload(ctx, r, "b", "", r.Size()); !errors.Is(err, ext_os.ErrNotModified) {
+	if err := storage.Upload(ctx, r, ext_os.UploadOptions{}); !errors.Is(err, ext_os.ErrNotModified) {
 		t.Fatalf("second upload: got %v, want ErrNotModified", err)
 	}
 
 	// Upload with different content should succeed.
 	r2 := bytes.NewReader([]byte("different content"))
-	if err := storage.Upload(ctx, r2, "b", "", r2.Size()); err != nil {
+	if err := storage.Upload(ctx, r2, ext_os.UploadOptions{}); err != nil {
 		t.Fatalf("third upload: %v", err)
 	}
 }
@@ -280,7 +280,7 @@ func TestFileSystemNotModified(t *testing.T) {
 
 	// First upload should write the file.
 	r := bytes.NewReader(content)
-	if err := storage.Upload(ctx, r, "b", "", r.Size()); err != nil {
+	if err := storage.Upload(ctx, r, ext_os.UploadOptions{}); err != nil {
 		t.Fatalf("first upload: %v", err)
 	}
 	if _, err := os.Stat(path); err != nil {
@@ -289,13 +289,13 @@ func TestFileSystemNotModified(t *testing.T) {
 
 	// Second upload with identical content should return ErrNotModified.
 	r = bytes.NewReader(content)
-	if err := storage.Upload(ctx, r, "b", "", r.Size()); !errors.Is(err, ext_os.ErrNotModified) {
+	if err := storage.Upload(ctx, r, ext_os.UploadOptions{}); !errors.Is(err, ext_os.ErrNotModified) {
 		t.Fatalf("second upload: got %v, want ErrNotModified", err)
 	}
 
 	// Upload with different content should succeed.
 	r2 := bytes.NewReader([]byte("different content"))
-	if err := storage.Upload(ctx, r2, "b", "", r2.Size()); err != nil {
+	if err := storage.Upload(ctx, r2, ext_os.UploadOptions{}); err != nil {
 		t.Fatalf("third upload: %v", err)
 	}
 }

--- a/pkg/objectstorage/objectstorage.go
+++ b/pkg/objectstorage/objectstorage.go
@@ -10,13 +10,21 @@ import (
 // is stored and no upload was performed.
 var ErrNotModified = errors.New("object not modified")
 
+// UploadOptions holds parameters for an Upload call.
+type UploadOptions struct {
+	Tenant    string
+	Name      string
+	Revision  string
+	TotalSize int64
+}
+
 // ObjectStorage defines the interface for uploading and downloading bundle artifacts
 // to/from object storage systems (e.g., S3, GCS, Azure Blob Storage).
 type ObjectStorage interface {
 	// Upload stores a bundle artifact in object storage.
 	// Implementations may return ErrNotModified to indicate that the upload
 	// was skipped because the content has not changed.
-	Upload(ctx context.Context, body io.ReadSeeker, name string, revision string, totalSize int64) error
+	Upload(ctx context.Context, body io.ReadSeeker, opts UploadOptions) error
 
 	// Download retrieves a bundle artifact from object storage.
 	Download(ctx context.Context) (io.Reader, error)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -458,7 +458,7 @@ func (s *Service) launchWorkers(ctx context.Context) {
 				WithInterval(b.Interval).
 				WithSingleShot(s.singleShot).
 				WithDatabase(s.Database()).
-				WithTenant(defaultTenant)
+				WithTenant(tenant)
 
 			if s.storage != nil {
 				w.WithStorage(s.storage)

--- a/pkg/service/worker.go
+++ b/pkg/service/worker.go
@@ -235,7 +235,12 @@ func (w *BundleWorker) Execute(ctx context.Context) time.Time {
 
 	if w.storage != nil {
 		reader := bytes.NewReader(buffer.Bytes())
-		if err := w.storage.Upload(ctx, reader, w.bundleConfig.Name, resolvedRevision, reader.Size()); err != nil {
+		if err := w.storage.Upload(ctx, reader, ext_os.UploadOptions{
+			Tenant:    w.tenant,
+			Name:      w.bundleConfig.Name,
+			Revision:  resolvedRevision,
+			TotalSize: reader.Size(),
+		}); err != nil {
 			if errors.Is(err, ext_os.ErrNotModified) {
 				w.log.Debugf("Bundle %q built, not modified.", w.bundleConfig.Name)
 				return w.report(ctx, BuildStateSuccess, startTime, nil)


### PR DESCRIPTION
This change replaces positional parameters (tenant, name, revision, totalSize) with
a single options struct. This makes the interface easier to
extend without breaking existing callers and new options can be added
without changing the Upload signature.