### PR TITLE
pkg: expose typed database config API

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -498,6 +498,32 @@ type Database struct {
 	_ struct{} `additionalProperties:"false"`
 }
 
+// DatabaseFromPublic converts the public DatabaseConfig to the internal Database config.
+func DatabaseFromPublic(cfg *extconfig.DatabaseConfig) *Database {
+	if cfg == nil {
+		return nil
+	}
+	result := &Database{}
+	if cfg.SQL != nil {
+		result.SQL = &SQLDatabase{
+			Driver: cfg.SQL.Driver,
+			DSN:    cfg.SQL.DSN,
+		}
+	}
+	if cfg.AWSRDS != nil {
+		result.AWSRDS = &AmazonRDS{
+			Region:           cfg.AWSRDS.Region,
+			Endpoint:         cfg.AWSRDS.Endpoint,
+			Driver:           cfg.AWSRDS.Driver,
+			DatabaseUser:     cfg.AWSRDS.DatabaseUser,
+			DatabaseName:     cfg.AWSRDS.DatabaseName,
+			DSN:              cfg.AWSRDS.DSN,
+			RootCertificates: cfg.AWSRDS.RootCertificates,
+		}
+	}
+	return result
+}
+
 type SQLDatabase struct {
 	Driver      string     `json:"driver"`
 	DSN         string     `json:"dsn"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -700,3 +700,26 @@ func (d *Datasource) Equal(other *Datasource) bool {
 func (a Datasources) Equal(b Datasources) bool {
 	return internalutil.SetEqual(a, b, func(ds Datasource) string { return ds.Name }, func(a, b Datasource) bool { return a.Equal(&b) })
 }
+
+// DatabaseConfig configures the OCP database connection.
+type DatabaseConfig struct {
+	SQL    *SQLDatabaseConfig `json:"sql,omitempty"`
+	AWSRDS *AmazonRDSConfig   `json:"aws_rds,omitempty"`
+}
+
+// SQLDatabaseConfig configures a generic SQL database connection.
+type SQLDatabaseConfig struct {
+	Driver string `json:"driver"`
+	DSN    string `json:"dsn"`
+}
+
+// AmazonRDSConfig configures an AWS RDS database connection.
+type AmazonRDSConfig struct {
+	Region           string `json:"region"`
+	Endpoint         string `json:"endpoint"`
+	Driver           string `json:"driver"`
+	DatabaseUser     string `json:"database_user"`
+	DatabaseName     string `json:"database_name"`
+	DSN              string `json:"dsn"`
+	RootCertificates string `json:"root_certificates,omitempty"`
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -8,8 +8,9 @@
 //
 //	db := database.New()
 //	db.WithAuthorizer(myAuthorizer)
-//	rawConfig := []byte(`{"database": {"sql": {"driver": "sqlite3", "dsn": "file::memory:?cache=shared"}}}`)
-//	if err := db.InitDB(ctx, rawConfig); err != nil {
+//	if err := db.InitDBWithConfig(ctx, &config.DatabaseConfig{
+//	    SQL: &config.SQLDatabaseConfig{Driver: "sqlite3", DSN: "file::memory:?cache=shared"},
+//	}); err != nil {
 //	    log.Fatal(err)
 //	}
 //	defer db.CloseDB()
@@ -33,6 +34,7 @@ import (
 
 	jp "github.com/evanphx/json-patch/v5"
 
+	internalconfig "github.com/open-policy-agent/opa-control-plane/internal/config"
 	internaldatabase "github.com/open-policy-agent/opa-control-plane/internal/database"
 	ext_authz "github.com/open-policy-agent/opa-control-plane/pkg/authz"
 	"github.com/open-policy-agent/opa-control-plane/pkg/config"
@@ -78,12 +80,15 @@ func (d *Database) WithAccessFactory(af ext_authz.AccessFactory) *Database {
 
 // InitDB initializes the database connection from a raw root configuration.
 //
-// The rawConfig must be a JSON (or YAML) document containing a "database" key.
-// Example:
-//
-//	{"database": {"sql": {"driver": "sqlite3", "dsn": "file::memory:?cache=shared"}}}
+// Deprecated: prefer InitDBWithConfig for type-safe configuration.
 func (d *Database) InitDB(ctx context.Context, rawConfig []byte) error {
 	d.db = d.db.WithRawRootConfig(rawConfig)
+	return d.db.InitDB(ctx)
+}
+
+// InitDBWithConfig initializes the database connection from a typed DatabaseConfig.
+func (d *Database) InitDBWithConfig(ctx context.Context, cfg *config.DatabaseConfig) error {
+	d.db = d.db.WithConfig(internalconfig.DatabaseFromPublic(cfg))
 	return d.db.InitDB(ctx)
 }
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/sqlsync"
 	ext_authz "github.com/open-policy-agent/opa-control-plane/pkg/authz"
 	"github.com/open-policy-agent/opa-control-plane/pkg/builder"
+	pkgconfig "github.com/open-policy-agent/opa-control-plane/pkg/config"
 	ext_os "github.com/open-policy-agent/opa-control-plane/pkg/objectstorage"
 )
 
@@ -159,6 +160,13 @@ func (s *Service) WithConfig(config *config.Root) *Service {
 func (s *Service) WithRawConfig(rawConfig []byte) *Service {
 	s.rawConfig = rawConfig
 	s.database = *s.database.WithRawRootConfig(rawConfig)
+	return s
+}
+
+// WithDatabaseConfig sets the database configuration from a typed DatabaseConfig,
+// as a type-safe alternative to WithRawConfig for database-only configuration.
+func (s *Service) WithDatabaseConfig(cfg *pkgconfig.DatabaseConfig) *Service {
+	s.database = *s.database.WithConfig(config.DatabaseFromPublic(cfg))
 	return s
 }
 


### PR DESCRIPTION
 ## Summary

  Add `DatabaseConfig`, `SQLDatabaseConfig`, and `AmazonRDSConfig` public types to `pkg/config` so callers can build typed database configuration instead of marshaling raw JSON/YAML bytes.

  Add `InitDBWithConfig` to `pkg/database.Database` and `WithDatabaseConfig` to `pkg/service.Service` as type-safe alternatives to `InitDB`/`WithRawConfig` for database-only configuration. Both existing methods are kept
  for backward compatibility.

  ## Changes

  - `pkg/config`: new `DatabaseConfig`, `SQLDatabaseConfig`, `AmazonRDSConfig` types
  - `pkg/database`: add `InitDBWithConfig(ctx, *config.DatabaseConfig)`, deprecate `InitDB`
  - `pkg/service`: add `WithDatabaseConfig(*config.DatabaseConfig)` alongside existing `WithRawConfig`