### PR TITLE
database: wrap driver errors in domain sentinel errors

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -2014,7 +2014,7 @@ func (d *Database) upsertReturning(ctx context.Context, returning, returningLast
 		if d.kind == mysql { // MySQL has no "... RETURNING (cols)"
 			result, err := tx.ExecContext(ctx, query, values...)
 			if err != nil {
-				return 0, err
+				return 0, translateStoreError(err)
 			}
 
 			if returningLastInsertID {
@@ -2033,12 +2033,12 @@ func (d *Database) upsertReturning(ctx context.Context, returning, returningLast
 		var id int
 		query += " RETURNING id"
 		if err := tx.QueryRowContext(ctx, query, values...).Scan(&id); err != nil {
-			return 0, err
+			return 0, translateStoreError(err)
 		}
 		return id, nil
 	} else {
 		_, err := tx.ExecContext(ctx, query, values...)
-		return 0, err
+		return 0, translateStoreError(err)
 	}
 }
 

--- a/internal/database/errors.go
+++ b/internal/database/errors.go
@@ -2,7 +2,60 @@ package database
 
 import (
 	"errors"
+	"fmt"
+	"strings"
+
+	mysqldriver "github.com/go-sql-driver/mysql"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 var ErrNotFound = errors.New("not found")
 var ErrNotAuthorized = errors.New("not authorized")
+
+// ErrAlreadyExists is returned when an insert violates a unique constraint.
+var ErrAlreadyExists = errors.New("already exists")
+
+// ErrConflict is returned when an operation conflicts with the current state
+// (e.g. a foreign key constraint violation).
+var ErrConflict = errors.New("conflict")
+
+// translateStoreError maps database-driver-specific constraint errors to
+// sentinel errors so callers do not need to import driver packages.
+func translateStoreError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		switch pgErr.Code {
+		case "23505": // unique_violation
+			return fmt.Errorf("%w: %s", ErrAlreadyExists, pgErr.Detail)
+		case "23503": // foreign_key_violation
+			return fmt.Errorf("%w: %s", ErrConflict, pgErr.Detail)
+		}
+		return err
+	}
+
+	var myErr *mysqldriver.MySQLError
+	if errors.As(err, &myErr) {
+		switch myErr.Number {
+		case 1062: // ER_DUP_ENTRY
+			return fmt.Errorf("%w: %s", ErrAlreadyExists, myErr.Message)
+		case 1451, 1452: // ER_ROW_IS_REFERENCED_2, ER_NO_REFERENCED_ROW_2
+			return fmt.Errorf("%w: %s", ErrConflict, myErr.Message)
+		}
+		return err
+	}
+
+	// SQLite unique constraint violation (modernc.org/sqlite driver)
+	msg := err.Error()
+	if strings.Contains(msg, "UNIQUE constraint failed") {
+		return fmt.Errorf("%w: %s", ErrAlreadyExists, msg)
+	}
+	if strings.Contains(msg, "FOREIGN KEY constraint failed") {
+		return fmt.Errorf("%w: %s", ErrConflict, msg)
+	}
+
+	return err
+}

--- a/internal/database/errors_test.go
+++ b/internal/database/errors_test.go
@@ -1,0 +1,92 @@
+package database
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	mysqldriver "github.com/go-sql-driver/mysql"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestTranslateStoreError_Nil(t *testing.T) {
+	if err := translateStoreError(nil); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestTranslateStoreError_PostgresUniqueViolation(t *testing.T) {
+	pgErr := &pgconn.PgError{Code: "23505", Detail: "Key (name)=(foo) already exists."}
+	err := translateStoreError(pgErr)
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("expected ErrAlreadyExists, got %v", err)
+	}
+}
+
+func TestTranslateStoreError_PostgresForeignKeyViolation(t *testing.T) {
+	pgErr := &pgconn.PgError{Code: "23503", Detail: "Key (bundle_id)=(42) not present in table bundles."}
+	err := translateStoreError(pgErr)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict, got %v", err)
+	}
+}
+
+func TestTranslateStoreError_PostgresOtherError(t *testing.T) {
+	pgErr := &pgconn.PgError{Code: "42P01", Message: "relation does not exist"}
+	err := translateStoreError(pgErr)
+	if errors.Is(err, ErrAlreadyExists) || errors.Is(err, ErrConflict) {
+		t.Fatalf("unexpected sentinel error for unrelated pg error: %v", err)
+	}
+	if !errors.As(err, &pgErr) {
+		t.Fatalf("expected original pgErr to be preserved, got %v", err)
+	}
+}
+
+func TestTranslateStoreError_MySQLDupEntry(t *testing.T) {
+	myErr := &mysqldriver.MySQLError{Number: 1062, Message: "Duplicate entry 'foo' for key 'PRIMARY'"}
+	err := translateStoreError(myErr)
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("expected ErrAlreadyExists, got %v", err)
+	}
+}
+
+func TestTranslateStoreError_MySQLForeignKey(t *testing.T) {
+	myErr := &mysqldriver.MySQLError{Number: 1452, Message: "Cannot add or update a child row"}
+	err := translateStoreError(myErr)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict, got %v", err)
+	}
+}
+
+func TestTranslateStoreError_SQLiteUniqueConstraint(t *testing.T) {
+	sqliteErr := fmt.Errorf("UNIQUE constraint failed: bundles.name, bundles.tenant_id")
+	err := translateStoreError(sqliteErr)
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("expected ErrAlreadyExists, got %v", err)
+	}
+}
+
+func TestTranslateStoreError_SQLiteForeignKey(t *testing.T) {
+	sqliteErr := fmt.Errorf("FOREIGN KEY constraint failed")
+	err := translateStoreError(sqliteErr)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict, got %v", err)
+	}
+}
+
+func TestTranslateStoreError_UnknownError(t *testing.T) {
+	orig := errors.New("some other database error")
+	err := translateStoreError(orig)
+	if err != orig {
+		t.Fatalf("expected original error to pass through, got %v", err)
+	}
+}
+
+func TestTranslateStoreError_WrappedPgError(t *testing.T) {
+	pgErr := &pgconn.PgError{Code: "23505", Detail: "Key (name)=(bar) already exists."}
+	wrapped := fmt.Errorf("upsert failed: %w", pgErr)
+	err := translateStoreError(wrapped)
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("expected ErrAlreadyExists from wrapped pgErr, got %v", err)
+	}
+}

--- a/internal/database/errors_test.go
+++ b/internal/database/errors_test.go
@@ -59,7 +59,7 @@ func TestTranslateStoreError_MySQLForeignKey(t *testing.T) {
 }
 
 func TestTranslateStoreError_SQLiteUniqueConstraint(t *testing.T) {
-	sqliteErr := fmt.Errorf("UNIQUE constraint failed: bundles.name, bundles.tenant_id")
+	sqliteErr := errors.New("UNIQUE constraint failed: bundles.name, bundles.tenant_id")
 	err := translateStoreError(sqliteErr)
 	if !errors.Is(err, ErrAlreadyExists) {
 		t.Fatalf("expected ErrAlreadyExists, got %v", err)
@@ -67,7 +67,7 @@ func TestTranslateStoreError_SQLiteUniqueConstraint(t *testing.T) {
 }
 
 func TestTranslateStoreError_SQLiteForeignKey(t *testing.T) {
-	sqliteErr := fmt.Errorf("FOREIGN KEY constraint failed")
+	sqliteErr := errors.New("FOREIGN KEY constraint failed")
 	err := translateStoreError(sqliteErr)
 	if !errors.Is(err, ErrConflict) {
 		t.Fatalf("expected ErrConflict, got %v", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -682,11 +682,15 @@ func (*Server) listOptions(r *http.Request) database.ListOptions {
 }
 
 func errorAuto(w http.ResponseWriter, err error) {
-	switch err {
-	case database.ErrNotAuthorized:
+	switch {
+	case errors.Is(err, database.ErrNotAuthorized):
 		ErrorString(w, http.StatusForbidden, types.CodeNotAuthorized, err)
-	case database.ErrNotFound:
+	case errors.Is(err, database.ErrNotFound):
 		ErrorString(w, http.StatusNotFound, types.CodeNotFound, err)
+	case errors.Is(err, database.ErrAlreadyExists):
+		ErrorString(w, http.StatusConflict, types.CodeAlreadyExists, err)
+	case errors.Is(err, database.ErrConflict):
+		ErrorString(w, http.StatusConflict, types.CodeConflict, err)
 	default:
 		ErrorString(w, http.StatusInternalServerError, types.CodeInternal, err)
 	}

--- a/internal/server/types/types.go
+++ b/internal/server/types/types.go
@@ -11,6 +11,8 @@ const (
 	CodeInternal         = "internal_error"
 	CodeNotAuthorized    = "not_authorized"
 	CodeNotFound         = "not_found"
+	CodeAlreadyExists    = "already_exists"
+	CodeConflict         = "conflict"
 	CodeInvalidParameter = "invalid_parameter"
 )
 

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -42,6 +42,8 @@ import (
 var (
 	ErrNotFound      = internaldatabase.ErrNotFound
 	ErrNotAuthorized = internaldatabase.ErrNotAuthorized
+	ErrAlreadyExists = internaldatabase.ErrAlreadyExists
+	ErrConflict      = internaldatabase.ErrConflict
 )
 
 // ErrInvalidJSON indicates the provided JSON could not be deserialized into the expected type.


### PR DESCRIPTION
OCP store layer now translates pgconn.PgError (PostgreSQL/CockroachDB), mysql.MySQLError, and SQLite constraint errors into ErrAlreadyExists and ErrConflict before returning to callers, so upstream consumers can use errors.Is() without importing database driver packages.

- Add ErrAlreadyExists and ErrConflict sentinel errors
- Add translateStoreError() called at all upsertReturning return paths
- Update errorAuto() to use errors.Is() and handle new error types
- Add CodeAlreadyExists and CodeConflict HTTP error codes
- Re-export new sentinel errors from pkg/database