### PR TITLE
objectstorage: add tenant param to Upload; database: add UpsertTenant…

### DIFF
--- a/internal/database/principal.go
+++ b/internal/database/principal.go
@@ -32,3 +32,24 @@ func (db *Database) GetPrincipalID(ctx context.Context, apiKey string) (string, 
 	var principalId string
 	return principalId, row.Scan(&principalId)
 }
+
+// UpsertTenantAndPrincipal creates a tenant and its principal in a single transaction.
+// Both operations use ON CONFLICT DO NOTHING / DO UPDATE, so retries are safe.
+func (db *Database) UpsertTenantAndPrincipal(ctx context.Context, tenantName, principalID, role string) error {
+	return tx1(ctx, db, func(tx *sql.Tx) error {
+		if err := db.upsertTenantTx(ctx, tx, tenantName); err != nil {
+			return fmt.Errorf("failed to upsert tenant: %w", err)
+		}
+		return db.UpsertPrincipalTx(ctx, tx, Principal{
+			Id:     principalID,
+			Role:   role,
+			Tenant: tenantName,
+		})
+	})
+}
+
+func (db *Database) upsertTenantTx(ctx context.Context, tx *sql.Tx, name string) error {
+	query := fmt.Sprintf("INSERT INTO tenants (name) VALUES (%s) ON CONFLICT (name) DO NOTHING", db.arg(0))
+	_, err := tx.ExecContext(ctx, query, name)
+	return err
+}

--- a/internal/s3/s3.go
+++ b/internal/s3/s3.go
@@ -206,7 +206,7 @@ func (e *Error) Error() string {
 // Upload uploads a file to the S3-compatible storage. It computes the SHA256 digest of the file and records that to the object metadata.
 // Relying on object ETag is not if the object is encrypted with SSE-C or SSE-KMS, as the ETag will not be the MD5 hash of the object.
 // With (part) checksums, only parallellizable, less reliable checksums (CRCs) are supported.
-func (s *AmazonS3) Upload(ctx context.Context, body io.ReadSeeker, _ string, revision string, _ int64) error {
+func (s *AmazonS3) Upload(ctx context.Context, body io.ReadSeeker, _ string, _ string, revision string, _ int64) error {
 
 	digest, equal, err := s.check(ctx, body)
 	if err != nil {
@@ -278,7 +278,7 @@ func (s *AmazonS3) check(ctx context.Context, body io.Reader) ([]byte, bool, err
 	return digest, output.Metadata["sha256"] == hex.EncodeToString(digest), nil
 }
 
-func (s *GCPCloudStorage) Upload(ctx context.Context, body io.ReadSeeker, _ string, revision string, _ int64) error {
+func (s *GCPCloudStorage) Upload(ctx context.Context, body io.ReadSeeker, _ string, _ string, revision string, _ int64) error {
 	w := s.client.Bucket(s.bucket).Object(s.object).NewWriter(ctx)
 	if w.Metadata == nil {
 		w.Metadata = make(map[string]string)
@@ -297,7 +297,7 @@ func (*GCPCloudStorage) Download(context.Context) (io.Reader, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (s *AzureBlobStorage) Upload(ctx context.Context, body io.ReadSeeker, _ string, revision string, _ int64) error {
+func (s *AzureBlobStorage) Upload(ctx context.Context, body io.ReadSeeker, _ string, _ string, revision string, _ int64) error {
 	opts := &azblob.UploadStreamOptions{}
 	if revision != "" {
 		opts.Metadata = map[string]*string{
@@ -312,7 +312,7 @@ func (*AzureBlobStorage) Download(context.Context) (io.Reader, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (s *FileSystemStorage) Upload(ctx context.Context, body io.ReadSeeker, _ string, _ string, _ int64) error {
+func (s *FileSystemStorage) Upload(ctx context.Context, body io.ReadSeeker, _ string, _ string, _ string, _ int64) error {
 	digest, equal, err := s.check(ctx, body)
 	if err != nil {
 		return err

--- a/internal/s3/s3_test.go
+++ b/internal/s3/s3_test.go
@@ -52,7 +52,7 @@ func TestS3(t *testing.T) {
 	}
 
 	bundle := bytes.NewReader([]byte("bundle content"))
-	err = storage.Upload(ctx, bundle, "testbundle", "", bundle.Size())
+	err = storage.Upload(ctx, bundle, "testbundle", "", "", bundle.Size())
 	if err != nil {
 		t.Fatalf("expected no error while uploading bundle: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestS3WithRevision(t *testing.T) {
 	bundleContent := []byte("bundle content with revision")
 	bundle := bytes.NewReader(bundleContent)
 	revision := "v1.2.3"
-	err = storage.Upload(ctx, bundle, "testbundle", revision, bundle.Size())
+	err = storage.Upload(ctx, bundle, "testbundle", "", revision, bundle.Size())
 	if err != nil {
 		t.Fatalf("expected no error while uploading bundle: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestS3WithoutRevision(t *testing.T) {
 	// Upload a bundle without a revision
 	bundleContent := []byte("bundle content without revision")
 	bundle := bytes.NewReader(bundleContent)
-	err = storage.Upload(ctx, bundle, "testbundle", "", bundle.Size())
+	err = storage.Upload(ctx, bundle, "testbundle", "", "", bundle.Size())
 	if err != nil {
 		t.Fatalf("expected no error while uploading bundle: %v", err)
 	}
@@ -246,19 +246,19 @@ func TestS3NotModified(t *testing.T) {
 
 	// First upload should succeed.
 	r := bytes.NewReader(content)
-	if err := storage.Upload(ctx, r, "b", "", r.Size()); err != nil {
+	if err := storage.Upload(ctx, r, "b", "", "", r.Size()); err != nil {
 		t.Fatalf("first upload: %v", err)
 	}
 
 	// Second upload with identical content should return ErrNotModified.
 	r = bytes.NewReader(content)
-	if err := storage.Upload(ctx, r, "b", "", r.Size()); !errors.Is(err, ext_os.ErrNotModified) {
+	if err := storage.Upload(ctx, r, "b", "", "", r.Size()); !errors.Is(err, ext_os.ErrNotModified) {
 		t.Fatalf("second upload: got %v, want ErrNotModified", err)
 	}
 
 	// Upload with different content should succeed.
 	r2 := bytes.NewReader([]byte("different content"))
-	if err := storage.Upload(ctx, r2, "b", "", r2.Size()); err != nil {
+	if err := storage.Upload(ctx, r2, "b", "", "", r2.Size()); err != nil {
 		t.Fatalf("third upload: %v", err)
 	}
 }
@@ -280,7 +280,7 @@ func TestFileSystemNotModified(t *testing.T) {
 
 	// First upload should write the file.
 	r := bytes.NewReader(content)
-	if err := storage.Upload(ctx, r, "b", "", r.Size()); err != nil {
+	if err := storage.Upload(ctx, r, "b", "", "", r.Size()); err != nil {
 		t.Fatalf("first upload: %v", err)
 	}
 	if _, err := os.Stat(path); err != nil {
@@ -289,13 +289,13 @@ func TestFileSystemNotModified(t *testing.T) {
 
 	// Second upload with identical content should return ErrNotModified.
 	r = bytes.NewReader(content)
-	if err := storage.Upload(ctx, r, "b", "", r.Size()); !errors.Is(err, ext_os.ErrNotModified) {
+	if err := storage.Upload(ctx, r, "b", "", "", r.Size()); !errors.Is(err, ext_os.ErrNotModified) {
 		t.Fatalf("second upload: got %v, want ErrNotModified", err)
 	}
 
 	// Upload with different content should succeed.
 	r2 := bytes.NewReader([]byte("different content"))
-	if err := storage.Upload(ctx, r2, "b", "", r2.Size()); err != nil {
+	if err := storage.Upload(ctx, r2, "b", "", "", r2.Size()); err != nil {
 		t.Fatalf("third upload: %v", err)
 	}
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -219,3 +219,9 @@ func (d *Database) UpsertPrincipal(ctx context.Context, id, role, tenant string)
 		Tenant: tenant,
 	})
 }
+
+// UpsertTenantWithPrincipal creates a tenant and its principal in a single transaction.
+// Both operations are idempotent (ON CONFLICT DO NOTHING / DO UPDATE), so retries are safe.
+func (d *Database) UpsertTenantWithPrincipal(ctx context.Context, tenantName, principalID, role string) error {
+	return d.db.UpsertTenantAndPrincipal(ctx, tenantName, principalID, role)
+}

--- a/pkg/objectstorage/objectstorage.go
+++ b/pkg/objectstorage/objectstorage.go
@@ -16,7 +16,7 @@ type ObjectStorage interface {
 	// Upload stores a bundle artifact in object storage.
 	// Implementations may return ErrNotModified to indicate that the upload
 	// was skipped because the content has not changed.
-	Upload(ctx context.Context, body io.ReadSeeker, name string, revision string, totalSize int64) error
+	Upload(ctx context.Context, body io.ReadSeeker, name string, tenant string, revision string, totalSize int64) error
 
 	// Download retrieves a bundle artifact from object storage.
 	Download(ctx context.Context) (io.Reader, error)

--- a/pkg/service/worker.go
+++ b/pkg/service/worker.go
@@ -235,7 +235,7 @@ func (w *BundleWorker) Execute(ctx context.Context) time.Time {
 
 	if w.storage != nil {
 		reader := bytes.NewReader(buffer.Bytes())
-		if err := w.storage.Upload(ctx, reader, w.bundleConfig.Name, resolvedRevision, reader.Size()); err != nil {
+		if err := w.storage.Upload(ctx, reader, w.bundleConfig.Name, w.tenant, resolvedRevision, reader.Size()); err != nil {
 			if errors.Is(err, ext_os.ErrNotModified) {
 				w.log.Debugf("Bundle %q built, not modified.", w.bundleConfig.Name)
 				return w.report(ctx, BuildStateSuccess, startTime, nil)


### PR DESCRIPTION
…WithPrincipal

Add `tenant string` parameter to the `ObjectStorage.Upload` interface so that callers can construct tenant-scoped storage paths. Update all implementations (AmazonS3, GCPCloudStorage, AzureBlobStorage, FileSystemStorage) and the BundleWorker call site to pass the worker's tenant value.

Add `UpsertTenantWithPrincipal` to the public `pkg/database` API, backed by a new internal `UpsertTenantAndPrincipal` that atomically inserts the tenant and principal rows in a single transaction using ON CONFLICT DO NOTHING for safe idempotent retries.