### PR TITLE
sync: classify user errors from git, http, and S3 sources

### DIFF
--- a/internal/gitsync/gitsync.go
+++ b/internal/gitsync/gitsync.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	"github.com/open-policy-agent/opa-control-plane/internal/metrics"
+	"github.com/open-policy-agent/opa-control-plane/internal/syncerr"
 )
 
 // configFile is an internal config file used to track if a git repository
@@ -136,7 +137,11 @@ func (s *Synchronizer) Execute(ctx context.Context) (map[string]any, error) {
 	done, hash, err := s.execute(ctx)
 	if err != nil {
 		s.metrics.GitSyncFailed(s.sourceName, s.config.Repo)
-		return nil, fmt.Errorf("source %q: git synchronizer: %v: %w", s.sourceName, s.config.Repo, err)
+		wrapped := fmt.Errorf("source %q: git synchronizer: %v: %w", s.sourceName, s.config.Repo, err)
+		if isGitUserError(err) {
+			return nil, syncerr.UserError{Cause: wrapped}
+		}
+		return nil, wrapped
 	}
 	if done {
 		s.metrics.GitSyncSucceeded(s.sourceName, s.config.Repo, startTime)
@@ -498,4 +503,13 @@ func (a *tokenAuth) SetAuth(r *gohttp.Request) {
 	}
 
 	r.Header.Set("Authorization", "Bearer "+token)
+}
+
+// isGitUserError returns true for errors that indicate a user misconfiguration
+// (bad credentials, non-existent repo) rather than a transient service failure.
+func isGitUserError(err error) bool {
+	return errors.Is(err, transport.ErrRepositoryNotFound) ||
+		errors.Is(err, transport.ErrAuthorizationFailed) ||
+		errors.Is(err, transport.ErrAuthenticationRequired) ||
+		errors.Is(err, transport.ErrEmptyRemoteRepository)
 }

--- a/internal/gitsync/gitsync_test.go
+++ b/internal/gitsync/gitsync_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	"github.com/open-policy-agent/opa-control-plane/internal/gitsync"
+	"github.com/open-policy-agent/opa-control-plane/internal/syncerr"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -112,6 +113,57 @@ func TestGitsyncLocal(t *testing.T) {
 	if string(data) != "second commit" {
 		t.Fatalf("expected file content to be 'second commit', got: %s", string(data))
 	}
+}
+
+// TestGitsyncUserError verifies that Execute classifies errors as syncerr.UserError
+// only when they indicate a user misconfiguration (e.g. a non-existent repository),
+// and leaves other errors (e.g. a non-existent reference) unclassified.
+func TestGitsyncUserError(t *testing.T) {
+	t.Run("repository not found", func(t *testing.T) {
+		ref := "refs/heads/master"
+		s := gitsync.New(t.TempDir()+"/dst", config.Git{
+			Repo:      t.TempDir() + "/does-not-exist",
+			Reference: &ref,
+		}, "test-source")
+
+		_, err := s.Execute(t.Context())
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if !syncerr.IsUserError(err) {
+			t.Fatalf("expected a syncerr.UserError, got: %v", err)
+		}
+	})
+
+	t.Run("reference not found", func(t *testing.T) {
+		testRepositoryPath := t.TempDir() + "/testing"
+		repository, err := git.PlainInit(testRepositoryPath, false)
+		if err != nil {
+			t.Fatalf("expected no error while initializing test repository: %v", err)
+		}
+
+		w, err := repository.Worktree()
+		if err != nil {
+			t.Fatalf("expected no error while getting worktree: %v", err)
+		}
+		if _, err := w.Commit("init", &git.CommitOptions{Author: &object.Signature{}, AllowEmptyCommits: true}); err != nil {
+			t.Fatalf("expected no error while committing changes: %v", err)
+		}
+
+		ref := "refs/heads/does-not-exist"
+		s := gitsync.New(t.TempDir()+"/dst", config.Git{
+			Repo:      testRepositoryPath,
+			Reference: &ref,
+		}, "test-source")
+
+		_, err = s.Execute(t.Context())
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if syncerr.IsUserError(err) {
+			t.Fatalf("expected a plain error, got a syncerr.UserError: %v", err)
+		}
+	})
 }
 
 // TestGitsyncSSH tests the functionality of the gitsync package with an SSH server.

--- a/internal/httpsync/httpsync.go
+++ b/internal/httpsync/httpsync.go
@@ -2,6 +2,7 @@ package httpsync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,10 +12,12 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	internal_aws "github.com/open-policy-agent/opa-control-plane/internal/aws"
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	internalfs "github.com/open-policy-agent/opa-control-plane/internal/fs"
+	"github.com/open-policy-agent/opa-control-plane/internal/syncerr"
 	pkgsync "github.com/open-policy-agent/opa-control-plane/pkg/sync"
 )
 
@@ -139,7 +142,11 @@ func (s *HttpDataSynchronizer) executeHTTP(ctx context.Context) (io.ReadCloser, 
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		resp.Body.Close()
-		return nil, fmt.Errorf("unsuccessful status code %d", resp.StatusCode)
+		err := fmt.Errorf("unsuccessful status code %d", resp.StatusCode)
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+			return nil, syncerr.UserError{Cause: err}
+		}
+		return nil, err
 	}
 
 	return resp.Body, nil
@@ -160,6 +167,10 @@ func (s *HttpDataSynchronizer) executeS3(ctx context.Context) (io.ReadCloser, er
 		Key:    aws.String(key),
 	})
 	if err != nil {
+		var httpErr *awshttp.ResponseError
+		if errors.As(err, &httpErr) && httpErr.HTTPStatusCode() >= 400 && httpErr.HTTPStatusCode() < 500 {
+			return nil, syncerr.UserError{Cause: fmt.Errorf("S3 GetObject: %w", err)}
+		}
 		return nil, fmt.Errorf("S3 GetObject: %w", err)
 	}
 

--- a/internal/httpsync/httpsync_test.go
+++ b/internal/httpsync/httpsync_test.go
@@ -73,13 +73,13 @@ func TestHTTPDataSynchronizer_Error_BadStatusCode(t *testing.T) {
 	}
 
 	synchronizer := New(file, ts.URL, "", "", nil, nil)
-	_, err = synchronizer.Execute(t.Context())
-	if err == nil {
+	_, syncErr := synchronizer.Execute(t.Context())
+	if syncErr == nil {
 		t.Fatalf("expected error, got nil")
 	}
 	expectedError := "unsuccessful status code 400"
-	if err.Error() != expectedError {
-		t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+	if syncErr.Error() != expectedError {
+		t.Fatalf("expected error %q, got %q", expectedError, syncErr.Error())
 	}
 
 	data, err := os.ReadFile(file)
@@ -91,8 +91,8 @@ func TestHTTPDataSynchronizer_Error_BadStatusCode(t *testing.T) {
 		t.Fatal("downloaded data should be empty after an error")
 	}
 
-	if !syncerr.IsUserError(err) {
-		t.Fatalf("expected a syncerr.UserError for a 4xx response, got: %v", err)
+	if !syncerr.IsUserError(syncErr) {
+		t.Fatalf("expected a syncerr.UserError for a 4xx response, got: %v", syncErr)
 	}
 }
 

--- a/internal/httpsync/httpsync_test.go
+++ b/internal/httpsync/httpsync_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/backend/s3mem"
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
+	"github.com/open-policy-agent/opa-control-plane/internal/syncerr"
 )
 
 func TestHTTPDataSynchronizer(t *testing.T) {
@@ -88,6 +89,31 @@ func TestHTTPDataSynchronizer_Error_BadStatusCode(t *testing.T) {
 
 	if len(data) != 0 {
 		t.Fatal("downloaded data should be empty after an error")
+	}
+
+	if !syncerr.IsUserError(err) {
+		t.Fatalf("expected a syncerr.UserError for a 4xx response, got: %v", err)
+	}
+}
+
+// TestHTTPDataSynchronizer_Error_ServerError verifies that a 5xx response is not
+// classified as a syncerr.UserError, since it indicates a transient service-side
+// failure rather than a user misconfiguration.
+func TestHTTPDataSynchronizer_Error_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	file := path.Join(t.TempDir(), "foo/test.json")
+	synchronizer := New(file, ts.URL, "", "", nil, nil)
+	_, err := synchronizer.Execute(t.Context())
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if syncerr.IsUserError(err) {
+		t.Fatalf("expected a plain error for a 5xx response, got a syncerr.UserError: %v", err)
 	}
 }
 
@@ -475,5 +501,39 @@ func TestHTTPDataSynchronizer_WithS3(t *testing.T) {
 				t.Fatalf("expected data %q, got %q", tt.contents, string(data))
 			}
 		})
+	}
+}
+
+// TestHTTPDataSynchronizer_WithS3_UserError verifies that a 4xx response from S3
+// (e.g. fetching a key that does not exist) is classified as a syncerr.UserError.
+func TestHTTPDataSynchronizer_WithS3_UserError(t *testing.T) {
+	mock := s3mem.New()
+	ts := httptest.NewServer(gofakes3.New(mock).Server())
+	t.Cleanup(ts.Close)
+
+	if err := mock.CreateBucket("test-bucket"); err != nil {
+		t.Fatalf("failed to create bucket: %v", err)
+	}
+
+	secret := config.Secret{
+		Name: "awsAuth",
+		Value: map[string]any{
+			"type":              "aws_auth",
+			"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+			"secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		},
+	}
+
+	file := path.Join(t.TempDir(), "data.json")
+	s3URL := ts.URL + "/test-bucket/no-such-key.json"
+
+	synchronizer := NewS3(file, s3URL, "us-east-1", ts.URL, secret.Ref())
+	_, err := synchronizer.Execute(t.Context())
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if !syncerr.IsUserError(err) {
+		t.Fatalf("expected a syncerr.UserError for a 4xx S3 response, got: %v", err)
 	}
 }

--- a/internal/syncerr/syncerr.go
+++ b/internal/syncerr/syncerr.go
@@ -1,0 +1,34 @@
+// Package syncerr defines error types for source synchronization.
+package syncerr
+
+import (
+	"errors"
+	"fmt"
+)
+
+// UserError wraps a synchronization error that is caused by user
+// misconfiguration (e.g. invalid credentials, non-existent repository, bad
+// URL) rather than a transient service-side failure. These errors should not
+// be retried and should not contribute to service-health alerts.
+type UserError struct {
+	Cause error
+}
+
+func (e UserError) Error() string {
+	return e.Cause.Error()
+}
+
+func (e UserError) Unwrap() error {
+	return e.Cause
+}
+
+// IsUserError reports whether err (or any error in its chain) is a UserError.
+func IsUserError(err error) bool {
+	var u UserError
+	return errors.As(err, &u)
+}
+
+// Userf wraps a formatted message as a UserError.
+func Userf(format string, args ...any) UserError {
+	return UserError{Cause: fmt.Errorf(format, args...)}
+}

--- a/internal/syncerr/syncerr.go
+++ b/internal/syncerr/syncerr.go
@@ -1,10 +1,7 @@
 // Package syncerr defines error types for source synchronization.
 package syncerr
 
-import (
-	"errors"
-	"fmt"
-)
+import "errors"
 
 // UserError wraps a synchronization error that is caused by user
 // misconfiguration (e.g. invalid credentials, non-existent repository, bad
@@ -26,9 +23,4 @@ func (e UserError) Unwrap() error {
 func IsUserError(err error) bool {
 	var u UserError
 	return errors.As(err, &u)
-}
-
-// Userf wraps a formatted message as a UserError.
-func Userf(format string, args ...any) UserError {
-	return UserError{Cause: fmt.Errorf(format, args...)}
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -85,6 +85,7 @@ const (
 	BuildStateConfigError
 	BuildStateSuccess
 	BuildStateSyncFailed
+	BuildStateUserError
 	BuildStateTransformFailed
 	BuildStateBuildFailed
 	BuildStatePushFailed
@@ -103,6 +104,8 @@ func (s BuildState) String() string {
 		return "SUCCESS"
 	case BuildStateSyncFailed:
 		return "SYNC_FAILED"
+	case BuildStateUserError:
+		return "USER_ERROR"
 	case BuildStateTransformFailed:
 		return "TRANSFORM_FAILED"
 	case BuildStateBuildFailed:

--- a/pkg/service/worker.go
+++ b/pkg/service/worker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/logging"
 	"github.com/open-policy-agent/opa-control-plane/internal/metrics"
 	"github.com/open-policy-agent/opa-control-plane/internal/progress"
+	"github.com/open-policy-agent/opa-control-plane/internal/syncerr"
 	"github.com/open-policy-agent/opa-control-plane/pkg/builder"
 	ext_os "github.com/open-policy-agent/opa-control-plane/pkg/objectstorage"
 )
@@ -156,7 +157,11 @@ func (w *BundleWorker) Execute(ctx context.Context) time.Time {
 		metadata, err := ss.sync.Execute(ctx)
 		if err != nil {
 			w.log.Warnf("failed to synchronize bundle %q: %v", w.bundleConfig.Name, err)
-			return w.report(ctx, BuildStateSyncFailed, startTime, err)
+			state := BuildStateSyncFailed
+			if syncerr.IsUserError(err) {
+				state = BuildStateUserError
+			}
+			return w.report(ctx, state, startTime, err)
 		}
 		if metadata != nil {
 			if sourceMetadata[ss.sourceName] == nil {

--- a/pkg/service/worker_test.go
+++ b/pkg/service/worker_test.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/open-policy-agent/opa-control-plane/internal/config"
+	"github.com/open-policy-agent/opa-control-plane/internal/logging"
+	"github.com/open-policy-agent/opa-control-plane/internal/progress"
+	"github.com/open-policy-agent/opa-control-plane/internal/syncerr"
+)
+
+type fakeSynchronizer struct {
+	err error
+}
+
+func (f *fakeSynchronizer) Execute(context.Context) (map[string]any, error) {
+	return nil, f.err
+}
+
+func (f *fakeSynchronizer) Close(context.Context) {}
+
+// TestBundleWorkerExecute_SyncError verifies that a source synchronization failure is
+// reported as BuildStateUserError when the underlying error is a syncerr.UserError,
+// and as BuildStateSyncFailed otherwise.
+func TestBundleWorkerExecute_SyncError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expState BuildState
+	}{
+		{
+			name:     "user error is reported as BuildStateUserError",
+			err:      syncerr.UserError{Cause: errors.New("bad credentials")},
+			expState: BuildStateUserError,
+		},
+		{
+			name:     "plain error is reported as BuildStateSyncFailed",
+			err:      errors.New("connection reset"),
+			expState: BuildStateSyncFailed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			worker := NewBundleWorker(t.TempDir(), &config.Bundle{Name: "test_bundle"}, nil, nil,
+				logging.NewLogger(logging.Config{}), progress.New(true, 1, "test")).
+				WithSingleShot(true).
+				WithSynchronizers([]sourceSynchronizer{{
+					sync:       &fakeSynchronizer{err: tc.err},
+					sourceName: "test-source",
+					sourceType: "git",
+				}})
+
+			worker.Execute(t.Context())
+
+			if worker.status.State != tc.expState {
+				t.Fatalf("expected state %v, got %v", tc.expState, worker.status.State)
+			}
+		})
+	}
+}

--- a/pkg/service/worker_test.go
+++ b/pkg/service/worker_test.go
@@ -19,7 +19,7 @@ func (f *fakeSynchronizer) Execute(context.Context) (map[string]any, error) {
 	return nil, f.err
 }
 
-func (f *fakeSynchronizer) Close(context.Context) {}
+func (*fakeSynchronizer) Close(context.Context) {}
 
 // TestBundleWorkerExecute_SyncError verifies that a source synchronization failure is
 // reported as BuildStateUserError when the underlying error is a syncerr.UserError,


### PR DESCRIPTION
Add internal/syncerr.UserError to distinguish misconfiguration errors (bad credentials, non-existent repo, 4xx responses) from transient service failures.

- gitsync: wrap ErrRepositoryNotFound, ErrAuthorizationFailed, ErrAuthenticationRequired, ErrEmptyRemoteRepository as UserError
- httpsync: wrap 4xx HTTP responses as UserError; 5xx/transport errors remain plain errors
- httpsync S3: wrap 4xx AWS SDK responses (via ResponseError) as UserError
- worker: report BuildStateUserError (USER_ERROR) when sync fails with a UserError, keeping BuildStateSyncFailed for service-side failures
- service: add BuildStateUserError state and USER_ERROR string