### PR TITLE
service: use CockroachDB follower reads for periodic worker list refresh

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -118,6 +118,14 @@ type ListOptions struct {
 	Limit  int
 	Cursor string
 	name   string
+
+	// Stale allows the list query to read a slightly stale (a few seconds
+	// old) snapshot via CockroachDB follower reads instead of the current
+	// timestamp. Use this for internal bookkeeping reads (e.g. periodic
+	// worker refresh) that don't need up-to-the-moment consistency and
+	// would otherwise contend with concurrent writes to the same tables.
+	// No-op on non-CockroachDB dialects.
+	Stale bool
 }
 
 func (opts ListOptions) cursor() int64 {
@@ -699,6 +707,9 @@ func (d *Database) DeleteBundle(ctx context.Context, principal, tenant, name str
 
 func (d *Database) ListBundles(ctx context.Context, principal, tenant string, opts ListOptions) ([]*config.Bundle, string, error) {
 	return tx3(ctx, d, func(txn *sql.Tx) ([]*config.Bundle, string, error) {
+		if err := d.applyFollowerRead(ctx, txn, opts.Stale); err != nil {
+			return nil, "", err
+		}
 
 		ad := d.accessFactory().WithPrincipal(principal).WithTenant(tenant).WithResource("bundles").WithPermission("bundles.view")
 
@@ -999,6 +1010,9 @@ func (d *Database) DeleteSource(ctx context.Context, principal, tenant, name str
 // ListSources returns a list of sources in the database. Note it does not return the source data.
 func (d *Database) ListSources(ctx context.Context, principal, tenant string, opts ListOptions) ([]*config.Source, string, error) {
 	return tx3(ctx, d, func(txn *sql.Tx) ([]*config.Source, string, error) {
+		if err := d.applyFollowerRead(ctx, txn, opts.Stale); err != nil {
+			return nil, "", err
+		}
 
 		ad := d.accessFactory().WithPrincipal(principal).WithTenant(tenant).WithResource("sources").WithPermission("sources.view")
 		expr, err := d.authorizer.Partial(ctx, ad, map[string]ext_authz.SQLColumnRef{
@@ -1401,6 +1415,9 @@ func (d *Database) DeleteStack(ctx context.Context, principal, tenant, name stri
 
 func (d *Database) ListStacks(ctx context.Context, principal, tenant string, opts ListOptions) ([]*config.Stack, string, error) {
 	return tx3(ctx, d, func(txn *sql.Tx) ([]*config.Stack, string, error) {
+		if err := d.applyFollowerRead(ctx, txn, opts.Stale); err != nil {
+			return nil, "", err
+		}
 
 		ad := d.accessFactory().WithPrincipal(principal).WithTenant(tenant).WithResource("stacks").WithPermission("stacks.view")
 		expr, err := d.authorizer.Partial(ctx, ad, map[string]ext_authz.SQLColumnRef{
@@ -2159,4 +2176,17 @@ func tx3[T any, U bool | string](ctx context.Context, db *Database, f func(*sql.
 		return err
 	})
 	return t, u, err
+}
+
+// applyFollowerRead switches tx to read a slightly stale (a few seconds old)
+// snapshot via CockroachDB follower reads, so it reads a fixed point in the
+// past that can't conflict with concurrent writes to the tables it scans.
+// Must be called before any other statement runs on tx. No-op when stale
+// reads aren't requested, or outside CockroachDB.
+func (d *Database) applyFollowerRead(ctx context.Context, tx *sql.Tx, stale bool) error {
+	if !stale || d.kind != cockroach {
+		return nil
+	}
+	_, err := tx.ExecContext(ctx, "SET TRANSACTION AS OF SYSTEM TIME follower_read_timestamp()")
+	return err
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -572,6 +572,17 @@ func TestDatabase(t *testing.T) {
 							},
 						},
 					}),
+
+				// Run last, and after an explicit wait: CockroachDB follower
+				// reads (ListOptions.Stale) read a fixed point a few seconds
+				// in the past, which must be after the migrations that
+				// created this schema ran, or the read fails with "relation
+				// does not exist".
+				newTestCase("list bundles/sources/stacks (stale)").
+					Sleep(6 * time.Second).
+					ListBundlesStaleNoError().
+					ListSourcesStaleNoError().
+					ListStacksStaleNoError(),
 			}
 			for _, test := range tests {
 				t.Run(test.note, func(t *testing.T) {
@@ -605,6 +616,20 @@ func (tc *testCase) GetPrincipalByToken(token, exp string) *testCase {
 		if act != exp {
 			t.Fatalf("expected %q, got %q", exp, act)
 		}
+	})
+	return tc
+}
+
+// Sleep pauses before the next operation. Used before the ListOptions.Stale
+// test cases: CockroachDB follower reads read a fixed point a few seconds in
+// the past (follower_read_timestamp()), so a stale read issued too soon
+// after the migrations that created the schema can fail with "relation does
+// not exist" - the read timestamp predates the DDL. Sleeping past that
+// window makes the assertion deterministic instead of depending on how much
+// incidental time earlier test cases happened to take.
+func (tc *testCase) Sleep(d time.Duration) *testCase {
+	tc.operations = append(tc.operations, func(ctx context.Context, t *testing.T, db *database.Database) {
+		time.Sleep(d)
 	})
 	return tc
 }
@@ -744,6 +769,22 @@ func (tc *testCase) ListBundlesPagination(limit int, expected []*config.Bundle) 
 	return tc
 }
 
+// ListBundlesStaleNoError exercises ListOptions.Stale (CockroachDB follower
+// reads). It only asserts the call succeeds, not the returned content: a
+// follower read intentionally reads a few-seconds-stale snapshot, so it may
+// not yet reflect writes from immediately before this call in the test
+// sequence, and a content assertion here would be flaky against a real
+// CockroachDB backend.
+func (tc *testCase) ListBundlesStaleNoError() *testCase {
+	tc.operations = append(tc.operations, func(ctx context.Context, t *testing.T, db *database.Database) {
+		if _, _, err := db.ListBundles(ctx, "admin", tenant, database.ListOptions{Stale: true}); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	return tc
+}
+
 func (tc *testCase) BundlesPutRequirements(id string, requirements config.Requirements) *testCase {
 	tc.operations = append(tc.operations, func(ctx context.Context, t *testing.T, db *database.Database) {
 		if err := db.UpsertBundle(ctx, "admin", tenant, &config.Bundle{
@@ -823,6 +864,18 @@ func (tc *testCase) ListSourcesPagination(limit int, expected []*config.Source) 
 
 		if diff := cmp.Diff(expected, sources); diff != "" {
 			t.Fatal("unexpected list result", diff)
+		}
+	})
+
+	return tc
+}
+
+// ListSourcesStaleNoError exercises ListOptions.Stale (CockroachDB follower
+// reads). See ListBundlesStaleNoError for why it doesn't assert content.
+func (tc *testCase) ListSourcesStaleNoError() *testCase {
+	tc.operations = append(tc.operations, func(ctx context.Context, t *testing.T, db *database.Database) {
+		if _, _, err := db.ListSources(ctx, "admin", tenant, database.ListOptions{Stale: true}); err != nil {
+			t.Fatalf("expected no error, got %v", err)
 		}
 	})
 
@@ -954,6 +1007,18 @@ func (tc *testCase) ListStacksPagination(limit int, expected []*config.Stack) *t
 
 		if diff := cmp.Diff(expected, stacks); diff != "" {
 			t.Fatal("unexpected list result", diff)
+		}
+	})
+
+	return tc
+}
+
+// ListStacksStaleNoError exercises ListOptions.Stale (CockroachDB follower
+// reads). See ListBundlesStaleNoError for why it doesn't assert content.
+func (tc *testCase) ListStacksStaleNoError() *testCase {
+	tc.operations = append(tc.operations, func(ctx context.Context, t *testing.T, db *database.Database) {
+		if _, _, err := db.ListStacks(ctx, "admin", tenant, database.ListOptions{Stale: true}); err != nil {
+			t.Fatalf("expected no error, got %v", err)
 		}
 	})
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -354,14 +354,14 @@ func (s *Service) launchWorkers(ctx context.Context) {
 		}
 		tenant := tenant.Name
 
-		bundles, _, err := s.database.ListBundles(ctx, internalPrincipal, tenant, database.ListOptions{})
+		bundles, _, err := s.database.ListBundles(ctx, internalPrincipal, tenant, database.ListOptions{Stale: true})
 		if err != nil {
 			s.log.Errorf("error listing bundles: %s", err.Error())
 			return
 		}
 		s.log.Debugf("launchWorkers(%s) for %d bundles", tenant, len(bundles))
 
-		sourceDefs, _, err := s.database.ListSources(ctx, internalPrincipal, tenant, database.ListOptions{})
+		sourceDefs, _, err := s.database.ListSources(ctx, internalPrincipal, tenant, database.ListOptions{Stale: true})
 		if err != nil {
 			s.log.Errorf("error listing sources: %s", err.Error())
 			return
@@ -372,7 +372,7 @@ func (s *Service) launchWorkers(ctx context.Context) {
 			sourceDefsByName[src.Name] = src
 		}
 
-		stacks, _, err := s.database.ListStacks(ctx, internalPrincipal, tenant, database.ListOptions{})
+		stacks, _, err := s.database.ListStacks(ctx, internalPrincipal, tenant, database.ListOptions{Stale: true})
 		if err != nil {
 			s.log.Errorf("error listing stacks: %s", err.Error())
 			return


### PR DESCRIPTION
## Why
`launchWorkers` periodically re-lists all bundles/sources/stacks for every tenant via broad multi-table LEFT JOIN queries (`ListBundles`, `ListSources`, `ListStacks`). These joins hold a read transaction open long enough, over the same tables that `Upsert*`/`Delete*` write to, that under load they see frequent CockroachDB serialization-conflict retries (each retry re-running the whole join, compounding latency/CPU).

## What
- `internal/database/database.go`: new `ListOptions.Stale` flag + `applyFollowerRead` helper that runs `SET TRANSACTION AS OF SYSTEM TIME follower_read_timestamp()` as the first statement in the transaction when `Stale=true` and the dialect is CockroachDB. No-op on SQLite/Postgres/MySQL, and no-op when `Stale` isn't set — other callers of `ListBundles`/`ListSources`/`ListStacks` that need fresh reads are unaffected.
- `pkg/service/service.go`: `launchWorkers`'s three periodic list calls now pass `Stale: true`. This bookkeeping read doesn't need up-to-the-moment consistency, so it's safe to read a few-seconds-stale snapshot that can't conflict with concurrently committing writes.

## Out of scope
The underlying queries are also each a single, wide multi-table JOIN with row fan-out (bundle x secrets x requirements) and no pagination limit in this call path — a separate, more invasive fix (splitting into flat batched queries) is left as a follow-up. This PR only addresses the contention/retry symptom for the periodic worker refresh path.

## Testing
- `go build ./...` — clean.
- `go vet ./internal/database/... ./pkg/service/...` — clean.
- `go test ./internal/database/...` (SQLite-backed subtests, which exercise `ListBundles`/`ListSources`/`ListStacks`) — pass.
- `gofmt -l` — clean on both changed files.
