### PR TITLE
Persist sync/transform failures in bundle status table

### DIFF
--- a/internal/database/bundle_status.go
+++ b/internal/database/bundle_status.go
@@ -11,15 +11,26 @@ import (
 
 const MaxBundleStatusRetention = 10
 
+// SentinelRevision keys the single "pre-revision state" row per bundle: the
+// outcome of failures that happen before a revision is resolved (sync, transform,
+// internal). It is the canonical value callers pass to UpsertBundleStatus for
+// pre-revision phases (e.g. pkg/service's worker). A present sentinel row means
+// the bundle is currently failing before the build phase (it is deleted as soon
+// as a real-revision row is written; see UpsertBundleStatus).
+const SentinelRevision = ""
+
 // UpsertBundleStatus creates or updates a bundle status record with the given phase and status.
 // For a given tenant+bundle+revision combination, only one record exists.
 // If a record already exists for the combination, it updates the phase and status.
+//
+// A revision of SentinelRevision (the empty string) records a pre-revision phase
+// (sync/transform/internal) and dedups to one sentinel row per bundle. When a
+// real (non-sentinel) revision is written, any existing sentinel row for the
+// bundle is deleted in the same transaction, so the sentinel never
+// lingers as a stale failure after the run gets past sync/transform.
+//
 // Old records beyond the retention limit (MaxBundleStatusRetention) are cleaned up in the same transaction.
 func (d *Database) UpsertBundleStatus(ctx context.Context, tenant, bundle, revision, phase, status, errMsg string) (int, error) {
-	if revision == "" {
-		return 0, errors.New("error inserting bundle status: revision is required")
-	}
-
 	var id int
 	err := tx1(ctx, d, func(tx *sql.Tx) error {
 
@@ -34,6 +45,22 @@ func (d *Database) UpsertBundleStatus(ctx context.Context, tenant, bundle, revis
 			return fmt.Errorf("error inserting bundle status: %w", err)
 		}
 		id = resID
+
+		// Self-healing: once we've written a real-revision row, the run got past
+		// sync/transform, so drop any stale pre-revision sentinel row for this
+		// bundle in the same transaction.
+		if revision != SentinelRevision {
+			if _, err := tx.ExecContext(ctx,
+				fmt.Sprintf(
+					`DELETE FROM bundles_statuses
+					 WHERE bundle_id = %s AND revision = %s`,
+					d.arg(0), d.arg(1),
+				),
+				bundleID, SentinelRevision,
+			); err != nil {
+				return fmt.Errorf("error clearing sentinel bundle status: %w", err)
+			}
+		}
 
 		// Cleanup: keep only the last MaxBundleStatusRetention records per tenant+bundle_id.
 		// This runs in the same transaction to ensure consistency.

--- a/internal/database/bundle_status_test.go
+++ b/internal/database/bundle_status_test.go
@@ -18,9 +18,10 @@ import (
 
 // Bundle status phases
 const (
-	PhaseSyncBundle  = "sync"
-	PhaseBuildBundle = "build"
-	PhasePushBundle  = "push"
+	PhaseSyncBundle      = "sync"
+	PhaseTransformBundle = "transform"
+	PhaseBuildBundle     = "build"
+	PhasePushBundle      = "push"
 )
 
 // Bundle status states
@@ -919,6 +920,165 @@ func TestUpsertBundleStatusRetentionCleanup(t *testing.T) {
 					require.NoError(t, err,
 						"bundle-b record with id %d should not be affected by bundle-a cleanup", id)
 				}
+			})
+		})
+	}
+}
+
+func countSentinelRows(ctx context.Context, t *testing.T, db *database.Database, bundle string) int {
+	t.Helper()
+	all, err := db.ListBundleStatuses(ctx, "admin", tenant, bundle, "", 0)
+	require.NoError(t, err)
+	n := 0
+	for _, s := range all {
+		if s.Revision == database.SentinelRevision {
+			n++
+		}
+	}
+	return n
+}
+
+func TestUpsertBundleStatusSentinel(t *testing.T) {
+	ctx := context.Background()
+
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				if databaseConfig.Cleanup != nil {
+					t.Cleanup(databaseConfig.Cleanup(t, ctr))
+				}
+			}
+
+			db, err := migrations.New().
+				WithConfig(databaseConfig.Database(t, ctr).Database).
+				WithLogger(logging.NewLogger(logging.Config{Level: logging.LevelDebug})).
+				WithMigrate(true).Run(ctx)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			defer db.CloseDB()
+
+			if err := db.UpsertPrincipal(ctx, principal); err != nil {
+				t.Fatal(err)
+			}
+
+			root := config.Root{
+				Bundles: map[string]*config.Bundle{
+					"bundle-a": {
+						Name: "bundle-a",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+					"bundle-b": {
+						Name: "bundle-b",
+						Requirements: config.Requirements{
+							config.Requirement{Source: newString("source-a")},
+						},
+					},
+				},
+				Sources: map[string]*config.Source{
+					"source-a": {
+						Name:         "source-a",
+						Requirements: config.Requirements{},
+					},
+				},
+				Database: &config.Database{
+					SQL: &config.SQLDatabase{
+						Driver: "sqlite3",
+						DSN:    database.SQLiteMemoryOnlyDSN,
+					},
+				},
+			}
+			if err := root.Unmarshal(); err != nil {
+				t.Fatalf("failed to unmarshal config: %v", err)
+			}
+
+			for _, op := range newTestCase("load config").LoadConfig(root).operations {
+				op(ctx, t, db)
+			}
+
+			t.Run("sentinel accepted and deduped", func(t *testing.T) {
+				id1, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", database.SentinelRevision, PhaseSyncBundle, "SYNC_FAILED", "boom")
+				require.NoError(t, err)
+
+				id2, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", database.SentinelRevision, PhaseSyncBundle, "SYNC_FAILED", "boom again")
+				require.NoError(t, err)
+				assert.Equal(t, id1, id2, "repeated sentinel upserts must reuse the single sentinel row")
+
+				statuses, err := db.ListBundleStatuses(ctx, "admin", tenant, "bundle-a", "", 0)
+				require.NoError(t, err)
+				assert.Len(t, statuses, 1, "exactly one sentinel row expected")
+				assert.Equal(t, database.SentinelRevision, statuses[0].Revision)
+				assert.Equal(t, "SYNC_FAILED", statuses[0].Status)
+			})
+
+			t.Run("sentinel is latest after recovery then re-failure", func(t *testing.T) {
+				_, err := db.UpsertBundleStatus(ctx, tenant, "bundle-b", database.SentinelRevision, PhaseSyncBundle, "SYNC_FAILED", "sync boom")
+				require.NoError(t, err)
+
+				_, err = db.UpsertBundleStatus(ctx, tenant, "bundle-b", "rev-1", PhasePushBundle, "SUCCESS", "")
+				require.NoError(t, err)
+
+				_, err = db.UpsertBundleStatus(ctx, tenant, "bundle-b", database.SentinelRevision, PhaseSyncBundle, "SYNC_FAILED", "sync boom 2")
+				require.NoError(t, err)
+
+				latest, err := db.GetLatestBundleStatus(ctx, "admin", tenant, "bundle-b")
+				require.NoError(t, err)
+				assert.Equal(t, "SYNC_FAILED", latest.Status)
+				assert.Equal(t, database.SentinelRevision, latest.Revision)
+			})
+
+			t.Run("real revision self-heals the sentinel", func(t *testing.T) {
+				_, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", database.SentinelRevision, PhaseTransformBundle, "TRANSFORM_FAILED", "bad rego")
+				require.NoError(t, err)
+
+				require.Equal(t, 1, countSentinelRows(ctx, t, db, "bundle-a"))
+
+				_, err = db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-heal", PhasePushBundle, "SUCCESS", "")
+				require.NoError(t, err)
+
+				// Sentinel gone, only the real-revision row remains.
+				assert.Equal(t, 0, countSentinelRows(ctx, t, db, "bundle-a"),
+					"sentinel row must be deleted after a real-revision write")
+
+				latest, err := db.GetLatestBundleStatus(ctx, "admin", tenant, "bundle-a")
+				require.NoError(t, err)
+				assert.Equal(t, "rev-heal", latest.Revision)
+				assert.Equal(t, "SUCCESS", latest.Status)
+			})
+
+			t.Run("self-heal on build failure after sync recovery", func(t *testing.T) {
+				_, err := db.UpsertBundleStatus(ctx, tenant, "bundle-b", database.SentinelRevision, PhaseSyncBundle, "SYNC_FAILED", "sync boom")
+				require.NoError(t, err)
+
+				_, err = db.UpsertBundleStatus(ctx, tenant, "bundle-b", "rev-2", PhaseBuildBundle, "BUILD_FAILED", "compile error")
+				require.NoError(t, err)
+
+				assert.Equal(t, 0, countSentinelRows(ctx, t, db, "bundle-b"),
+					"sentinel must be cleared once a real revision is written, even on build failure")
+
+				latest, err := db.GetLatestBundleStatus(ctx, "admin", tenant, "bundle-b")
+				require.NoError(t, err)
+				assert.Equal(t, "rev-2", latest.Revision)
+				assert.Equal(t, "BUILD_FAILED", latest.Status)
+			})
+
+			// Revision-scoped queries never return the sentinel row.
+			t.Run("revision scoping excludes sentinel", func(t *testing.T) {
+				_, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", database.SentinelRevision, PhaseSyncBundle, "SYNC_FAILED", "boom")
+				require.NoError(t, err)
+				_, err = db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-scope", PhasePushBundle, "SUCCESS", "")
+				require.NoError(t, err)
+
+				scoped, err := db.ListBundleStatuses(ctx, "admin", tenant, "bundle-a", "rev-scope", 0)
+				require.NoError(t, err)
+				require.Len(t, scoped, 1)
+				assert.Equal(t, "rev-scope", scoped[0].Revision)
 			})
 		})
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -92,7 +92,9 @@ const (
 )
 
 const (
-	BuildPhaseBuild BuildPhase = iota
+	BuildPhaseSync BuildPhase = iota
+	BuildPhaseTransform
+	BuildPhaseBuild
 	BuildPhasePush
 )
 
@@ -121,6 +123,10 @@ func (s BuildState) String() string {
 
 func (s BuildPhase) String() string {
 	switch s {
+	case BuildPhaseSync:
+		return "SYNC"
+	case BuildPhaseTransform:
+		return "TRANSFORM"
 	case BuildPhaseBuild:
 		return "BUILD"
 	case BuildPhasePush:

--- a/pkg/service/worker.go
+++ b/pkg/service/worker.go
@@ -146,7 +146,7 @@ func (w *BundleWorker) Execute(ctx context.Context) time.Time {
 	for _, src := range w.sources {
 		if err := src.Wipe(); err != nil {
 			w.log.Warnf("failed to remove a directory for bundle %q: %v", w.bundleConfig.Name, err)
-			return w.report(ctx, BuildStateInternalError, startTime, err)
+			return w.report(ctx, BuildStateInternalError, BuildPhaseSync, database.SentinelRevision, startTime, err)
 		}
 	}
 
@@ -161,7 +161,7 @@ func (w *BundleWorker) Execute(ctx context.Context) time.Time {
 			if syncerr.IsUserError(err) {
 				state = BuildStateUserError
 			}
-			return w.report(ctx, state, startTime, err)
+			return w.report(ctx, state, BuildPhaseSync, database.SentinelRevision, startTime, err)
 		}
 		if metadata != nil {
 			if sourceMetadata[ss.sourceName] == nil {
@@ -190,7 +190,7 @@ func (w *BundleWorker) Execute(ctx context.Context) time.Time {
 		}
 		if err != nil {
 			w.log.Warnf("failed to evaluate source %q for bundle %q: %v", src.Name, w.bundleConfig.Name, err)
-			return w.report(ctx, BuildStateTransformFailed, startTime, err)
+			return w.report(ctx, BuildStateTransformFailed, BuildPhaseTransform, database.SentinelRevision, startTime, err)
 		}
 	}
 
@@ -227,21 +227,7 @@ func (w *BundleWorker) Execute(ctx context.Context) time.Time {
 
 	if err := b.Build(ctx); err != nil {
 		w.log.Warnf("failed to build a bundle %q: %v", w.bundleConfig.Name, err)
-
-		if b.Revision() != "" {
-			_, err := w.database.UpsertBundleStatus(ctx, w.tenant, w.bundleConfig.Name, b.Revision(), BuildPhaseBuild.String(), BuildStateBuildFailed.String(), err.Error())
-			if err != nil {
-				w.log.Warnf("failed to track bundle build state %q: %v", w.bundleConfig.Name, err)
-			}
-		}
-		return w.report(ctx, BuildStateBuildFailed, startTime, err)
-	}
-
-	if b.Revision() != "" {
-		_, err := w.database.UpsertBundleStatus(ctx, w.tenant, w.bundleConfig.Name, b.Revision(), BuildPhaseBuild.String(), BuildStateSuccess.String(), "")
-		if err != nil {
-			w.log.Warnf("failed to track bundle build state %q: %v", w.bundleConfig.Name, err)
-		}
+		return w.report(ctx, BuildStateBuildFailed, BuildPhaseBuild, resolvedRevision, startTime, err)
 	}
 
 	if w.storage != nil {
@@ -254,40 +240,35 @@ func (w *BundleWorker) Execute(ctx context.Context) time.Time {
 		}); err != nil {
 			if errors.Is(err, ext_os.ErrNotModified) {
 				w.log.Debugf("Bundle %q built, not modified.", w.bundleConfig.Name)
-				return w.report(ctx, BuildStateSuccess, startTime, nil)
+				return w.report(ctx, BuildStateSuccess, BuildPhasePush, resolvedRevision, startTime, nil)
 			}
 			w.log.Warnf("failed to upload bundle %q: %v", w.bundleConfig.Name, err)
-
-			if b.Revision() != "" {
-				_, err := w.database.UpsertBundleStatus(ctx, w.tenant, w.bundleConfig.Name, b.Revision(), BuildPhasePush.String(), BuildStatePushFailed.String(), err.Error())
-				if err != nil {
-					w.log.Warnf("failed to track bundle upload state %q: %v", w.bundleConfig.Name, err)
-				}
-			}
-			return w.report(ctx, BuildStatePushFailed, startTime, err)
+			return w.report(ctx, BuildStatePushFailed, BuildPhasePush, resolvedRevision, startTime, err)
 		}
 
 		w.log.Debugf("Bundle %q built and uploaded.", w.bundleConfig.Name)
-
-		if b.Revision() != "" {
-			_, err := w.database.UpsertBundleStatus(ctx, w.tenant, w.bundleConfig.Name, b.Revision(), BuildPhasePush.String(), BuildStateSuccess.String(), "")
-			if err != nil {
-				w.log.Warnf("failed to track bundle upload state %q: %v", w.bundleConfig.Name, err)
-			}
-		}
-		return w.report(ctx, BuildStateSuccess, startTime, nil)
+		return w.report(ctx, BuildStateSuccess, BuildPhasePush, resolvedRevision, startTime, nil)
 	}
 
 	w.log.Debugf("Bundle %q built.", w.bundleConfig.Name)
-	return w.report(ctx, BuildStateSuccess, startTime, nil)
+	return w.report(ctx, BuildStateSuccess, BuildPhaseBuild, resolvedRevision, startTime, nil)
 }
 
-func (w *BundleWorker) report(ctx context.Context, state BuildState, startTime time.Time, err error) time.Time {
+func (w *BundleWorker) report(ctx context.Context, state BuildState, phase BuildPhase, revision string, startTime time.Time, err error) time.Time {
 	interval := w.interval
 	w.status.State = state
+	msg := ""
 	if err != nil {
 		interval = errorInterval // faster retry on error
-		w.status.Message = err.Error()
+		msg = err.Error()
+		w.status.Message = msg
+	}
+
+	if w.database != nil {
+		if _, uerr := w.database.UpsertBundleStatus(ctx, w.tenant, w.bundleConfig.Name,
+			revision, phase.String(), state.String(), msg); uerr != nil {
+			w.log.Warnf("failed to track bundle status %q: %v", w.bundleConfig.Name, uerr)
+		}
 	}
 
 	if state == BuildStateSuccess {

--- a/pkg/service/worker_test.go
+++ b/pkg/service/worker_test.go
@@ -6,9 +6,12 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
+	"github.com/open-policy-agent/opa-control-plane/internal/database"
 	"github.com/open-policy-agent/opa-control-plane/internal/logging"
+	"github.com/open-policy-agent/opa-control-plane/internal/migrations"
 	"github.com/open-policy-agent/opa-control-plane/internal/progress"
 	"github.com/open-policy-agent/opa-control-plane/internal/syncerr"
+	"github.com/open-policy-agent/opa-control-plane/internal/test/dbs"
 )
 
 type fakeSynchronizer struct {
@@ -59,5 +62,76 @@ func TestBundleWorkerExecute_SyncError(t *testing.T) {
 				t.Fatalf("expected state %v, got %v", tc.expState, worker.status.State)
 			}
 		})
+	}
+}
+
+// TestBundleWorkerExecute_SyncFailurePersisted verifies that a git-sync failure
+// produces a queryable SYNC_FAILED status row (persisted under the pre-revision
+// sentinel), proving report() centralizes the write for pre-revision phases.
+func TestBundleWorkerExecute_SyncFailurePersisted(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := migrations.New().
+		WithConfig(&config.Database{
+			SQL: &config.SQLDatabase{Driver: "sqlite3", DSN: dbs.MemoryDBName()},
+		}).
+		WithLogger(logging.NewLogger(logging.Config{})).
+		WithMigrate(true).Run(ctx)
+	if err != nil {
+		t.Fatalf("failed to init database: %v", err)
+	}
+	defer db.CloseDB()
+
+	const tenant = "default"
+	principal := database.Principal{Id: "admin", Role: "administrator", Tenant: tenant}
+	if err := db.UpsertPrincipal(ctx, principal); err != nil {
+		t.Fatal(err)
+	}
+
+	sourceName := "test-source"
+	root := config.Root{
+		Bundles: map[string]*config.Bundle{
+			"test_bundle": {
+				Name:         "test_bundle",
+				Requirements: config.Requirements{config.Requirement{Source: &sourceName}},
+			},
+		},
+		Sources: map[string]*config.Source{
+			"test-source": {Name: "test-source", Requirements: config.Requirements{}},
+		},
+		Database: &config.Database{SQL: &config.SQLDatabase{Driver: "sqlite3", DSN: database.SQLiteMemoryOnlyDSN}},
+	}
+	if err := root.Unmarshal(); err != nil {
+		t.Fatalf("failed to unmarshal config: %v", err)
+	}
+	if err := db.LoadConfig(ctx, nil, principal.Id, tenant, &root); err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	worker := NewBundleWorker(t.TempDir(), root.Bundles["test_bundle"], nil, nil,
+		logging.NewLogger(logging.Config{}), progress.New(true, 1, "test")).
+		WithSingleShot(true).
+		WithDatabase(db).
+		WithTenant(tenant).
+		WithSynchronizers([]sourceSynchronizer{{
+			sync:       &fakeSynchronizer{err: errors.New("connection reset")},
+			sourceName: "test-source",
+			sourceType: "git",
+		}})
+
+	worker.Execute(ctx)
+
+	status, err := db.GetLatestBundleStatus(ctx, principal.Id, tenant, "test_bundle")
+	if err != nil {
+		t.Fatalf("expected a persisted status, got error: %v", err)
+	}
+	if status.Status != BuildStateSyncFailed.String() {
+		t.Fatalf("expected status %q, got %q", BuildStateSyncFailed.String(), status.Status)
+	}
+	if status.Phase != BuildPhaseSync.String() {
+		t.Fatalf("expected phase %q, got %q", BuildPhaseSync.String(), status.Phase)
+	}
+	if status.Revision != database.SentinelRevision {
+		t.Fatalf("expected sentinel revision %q, got %q", database.SentinelRevision, status.Revision)
 	}
 }


### PR DESCRIPTION
Bundle builds run in four phases (sync, transform, build, push), but only build and push outcomes were persisted to the bundles_statuses table. Sync/transform failures were logged so operators querying bundle status could never see them. This change includes sync/transform failures in the bundle status table.

Behavior change: bundles without a configured revision previously produced no status rows at all so GetLatestBundleStatus returned ErrNotFound and the status API returned 404 for them. They now
persist a single status row keyed on the empty-string sentinel, updated in place each tick to reflect the current phase/state, so those queries now return a status instead of not-found. Bundles that always resolve a non-empty revision are unaffected.