### PR TITLE
service: add WithPrometheusRegisterer for callers without internal/metrics access

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -20,6 +20,7 @@ import (
 
 	pkgsync "github.com/open-policy-agent/opa-control-plane/pkg/sync"
 	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/prometheus/client_golang/prometheus"
 	_ "modernc.org/sqlite"
 
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
@@ -165,6 +166,16 @@ func (s *Service) WithAuthorizer(a ext_authz.Authorizer) *Service {
 func (s *Service) WithMetrics(m *metrics.Metrics) *Service {
 	s.metrics = m
 	return s
+}
+
+// WithPrometheusRegisterer enables OCP's built-in metrics (git sync, HTTP,
+// bundle build) to be recorded against reg, using default metrics
+// configuration (all metrics enabled, default histogram buckets). This is a
+// convenience for callers that only have a prometheus.Registerer and don't
+// need the finer-grained per-metric enable/disable or bucket overrides
+// available via MetricsConfig; use WithMetrics directly for that.
+func (s *Service) WithPrometheusRegisterer(reg prometheus.Registerer) *Service {
+	return s.WithMetrics(metrics.Init(nil, reg))
 }
 
 func (s *Service) WithConfig(config *config.Root) *Service {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/logging"
 	"github.com/open-policy-agent/opa-control-plane/pkg/service"
 	pkgsync "github.com/open-policy-agent/opa-control-plane/pkg/sync"
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -55,6 +56,73 @@ func TestUnconfiguredSecretHandling(t *testing.T) {
 		t.Fatal("expected sync failure state")
 	} else if status.Message != `source "test_src": git synchronizer: https://example.com/repo.git: secret "test_creds" is not configured` {
 		t.Fatal("unexpected status message")
+	}
+}
+
+// TestWithPrometheusRegisterer verifies that git sync metrics are recorded
+// against a caller-provided Prometheus registerer without requiring callers
+// to construct a *metrics.Metrics themselves (that type lives in an internal
+// package and is not reachable outside this module).
+func TestWithPrometheusRegisterer(t *testing.T) {
+	bs := fmt.Appendf(nil, `{
+		bundles: {
+			test_bundle: {
+				object_storage: {
+					filesystem: {
+						path: %q
+					}
+				},
+				requirements: [
+					{source: test_src}
+				]
+			}
+		},
+		sources: {
+			test_src: {
+				git: {
+					repo: https://example.com/repo.git,
+					credentials: test_creds,
+					reference: refs/heads/main,
+				}
+			}
+		},
+		secrets: {
+			test_creds: {} # not configured
+		}
+	}`, filepath.Join(t.TempDir(), "bundles"))
+
+	cfg, err := config.Parse(bs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reg := prometheus.NewRegistry()
+	dir := t.TempDir()
+	svc := service.New().
+		WithConfig(cfg).
+		WithPersistenceDir(filepath.Join(dir, "data")).
+		WithSingleShot(true).
+		WithMigrateDB(true).
+		WithPrometheusRegisterer(reg)
+
+	if err := svc.Run(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var found bool
+	for _, f := range families {
+		if f.GetName() == "ocp_git_sync_count_total" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected ocp_git_sync_count_total to be registered and recorded")
 	}
 }
 


### PR DESCRIPTION
## Summary
`Service.WithMetrics` already accepts a `*metrics.Metrics`, but that type lives in `internal/metrics` and is unreachable from outside this module (Go enforces `internal/` package visibility). External callers that only have a `prometheus.Registerer` (e.g. a consuming service that already builds its own registry) have no way to opt into OCP's built-in git sync, HTTP, and bundle build metrics.

This adds a small convenience method:

```go
func (s *Service) WithPrometheusRegisterer(reg prometheus.Registerer) *Service {
	return s.WithMetrics(metrics.Init(nil, reg))
}
```

It wraps `metrics.Init` with a nil `MetricsConfig`, which enables all metrics with default histogram buckets. Callers that need finer-grained per-metric enable/disable or custom buckets should keep using `WithMetrics` directly (not reachable externally without vendoring `internal/config`, but that's an existing constraint, not something this PR changes).

## Test plan
- Added `TestWithPrometheusRegisterer`, which runs a real (failing, unconfigured-secret) git sync through `Service` with a custom `prometheus.Registry` and asserts `ocp_git_sync_count_total` is present after `Gather()`, proving the wiring reaches `gitsync.Synchronizer`'s metrics recording.
- `go test ./pkg/service/...` passes for this test and all other non-network-bound tests in the package.
