### PR TITLE
database: add per-query Prometheus metrics

### DIFF
--- a/config/schema.json
+++ b/config/schema.json
@@ -122,6 +122,24 @@
       },
       "type": "object"
     },
+    "ConfigDatabaseMetrics": {
+      "additionalProperties": false,
+      "properties": {
+        "database_query_count": {
+          "$ref": "#/definitions/ConfigCounterConfig"
+        },
+        "database_query_duration": {
+          "$ref": "#/definitions/ConfigHistogramConfig"
+        },
+        "enabled": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "ConfigDatasource": {
       "additionalProperties": false,
       "properties": {
@@ -304,6 +322,9 @@
     "ConfigMetricsConfig": {
       "additionalProperties": false,
       "properties": {
+        "database": {
+          "$ref": "#/definitions/ConfigDatabaseMetrics"
+        },
         "enabled": {
           "type": [
             "null",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -603,12 +603,22 @@ type WorkerMetrics struct {
 	_ struct{} `additionalProperties:"false"`
 }
 
+// DatabaseMetrics configures database query metrics.
+type DatabaseMetrics struct {
+	Enabled               *bool            `json:"enabled,omitempty"`
+	DatabaseQueryDuration *HistogramConfig `json:"database_query_duration,omitempty"`
+	DatabaseQueryCount    *CounterConfig   `json:"database_query_count,omitempty"`
+
+	_ struct{} `additionalProperties:"false"`
+}
+
 // MetricsConfig configures Prometheus metrics collection.
 type MetricsConfig struct {
-	Enabled *bool           `json:"enabled,omitempty"`
-	HTTP    *HTTPMetrics    `json:"http,omitempty"`
-	GitSync *GitSyncMetrics `json:"gitsync,omitempty"`
-	Worker  *WorkerMetrics  `json:"worker,omitempty"`
+	Enabled  *bool            `json:"enabled,omitempty"`
+	HTTP     *HTTPMetrics     `json:"http,omitempty"`
+	GitSync  *GitSyncMetrics  `json:"gitsync,omitempty"`
+	Worker   *WorkerMetrics   `json:"worker,omitempty"`
+	Database *DatabaseMetrics `json:"database,omitempty"`
 
 	_ struct{} `additionalProperties:"false"`
 }
@@ -635,4 +645,12 @@ func (w *WorkerMetrics) GetCountEnabled() *bool {
 		return nil
 	}
 	return w.BundleBuildCount.Enabled
+}
+
+// GetCountEnabled returns the Enabled pointer from the counter config, or nil if the receiver is nil.
+func (d *DatabaseMetrics) GetCountEnabled() *bool {
+	if d == nil || d.DatabaseQueryCount == nil {
+		return nil
+	}
+	return d.DatabaseQueryCount.Enabled
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -35,6 +35,7 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/logging"
 	"github.com/open-policy-agent/opa-control-plane/internal/progress"
 	ext_authz "github.com/open-policy-agent/opa-control-plane/pkg/authz"
+	"github.com/open-policy-agent/opa-control-plane/pkg/metrics"
 )
 
 const (
@@ -56,6 +57,7 @@ type Database struct {
 	executeTx     func(context.Context, *sql.DB, *sql.TxOptions, func(*sql.Tx) error) error
 	authorizer    ext_authz.Authorizer
 	accessFactory ext_authz.AccessFactory
+	metrics       *metrics.Metrics
 }
 
 func New() *Database {
@@ -167,6 +169,22 @@ func (d *Database) WithAuthorizer(authorizer ext_authz.Authorizer) *Database {
 func (d *Database) WithAccessFactory(accessFactory ext_authz.AccessFactory) *Database {
 	d.accessFactory = accessFactory
 	return d
+}
+
+// WithMetrics enables per-query metrics (count and duration by outcome) for
+// this Database's connections. Pass nil to disable (the default).
+func (d *Database) WithMetrics(m *metrics.Metrics) *Database {
+	d.metrics = m
+	return d
+}
+
+// instrumentConnector wraps connector with query metrics if metrics are
+// configured, otherwise it returns connector unchanged.
+func (d *Database) instrumentConnector(connector driver.Connector) driver.Connector {
+	if d.metrics == nil {
+		return connector
+	}
+	return newInstrumentedConnector(connector, d.metrics)
 }
 
 func (d *Database) InitDB(ctx context.Context) error {
@@ -358,7 +376,7 @@ func (d *Database) InitDB(ctx context.Context) error {
 			return fmt.Errorf("unsupported AWS RDS driver: %s", drv)
 		}
 
-		d.db = sql.OpenDB(connector)
+		d.db = sql.OpenDB(d.instrumentConnector(connector))
 
 		d.log.Debugf("Connected to %s RDS instance at %s", drv, endpoint)
 
@@ -398,7 +416,7 @@ func (d *Database) InitDB(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		d.db = sql.OpenDB(pgx_stdlib.GetConnector(*cfg))
+		d.db = sql.OpenDB(d.instrumentConnector(pgx_stdlib.GetConnector(*cfg)))
 
 	case d.config.SQL.Driver == "mysql":
 		dsn := os.ExpandEnv(d.config.SQL.DSN)
@@ -419,7 +437,7 @@ func (d *Database) InitDB(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		d.db = sql.OpenDB(conn)
+		d.db = sql.OpenDB(d.instrumentConnector(conn))
 
 	default:
 		return errors.New("unsupported database connection type")

--- a/internal/database/instrumented.go
+++ b/internal/database/instrumented.go
@@ -1,0 +1,208 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"time"
+
+	"github.com/open-policy-agent/opa-control-plane/pkg/metrics"
+)
+
+// instrumentedConnector wraps a driver.Connector so every driver.Conn it
+// produces records query metrics. Connect is a straight pass-through; the
+// returned Conn is wrapped by instrumentedConn (see below).
+type instrumentedConnector struct {
+	driver.Connector
+	metrics *metrics.Metrics
+}
+
+func newInstrumentedConnector(inner driver.Connector, m *metrics.Metrics) driver.Connector {
+	return instrumentedConnector{Connector: inner, metrics: m}
+}
+
+func (c instrumentedConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	conn, err := c.Connector.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return wrapConn(conn, c.metrics), nil
+}
+
+// instrumentedConn wraps a driver.Conn to record query metrics. It must
+// implement every optional driver.Conn interface (QueryerContext,
+// ExecerContext, Pinger, ...) that database/sql knows how to detect, since
+// database/sql picks its execution path based on which interfaces a Conn
+// implements — a wrapper that omits one silently changes behavior (e.g.
+// falling back to a slower path) instead of erroring.
+//
+// Following the pattern used by github.com/XSAM/otelsql (see conn.go
+// there), each method checks at call time whether the wrapped conn
+// actually implements the corresponding interface:
+//   - If not, it returns driver.ErrSkip (the sentinel database/sql defines
+//     for exactly this situation), which tells database/sql to fall back to
+//     the next mechanism (e.g. prepare-then-query) — identical to what
+//     would happen without any wrapping.
+//   - If so, it forwards the call, recording metrics around it where
+//     relevant (QueryContext/ExecContext).
+type instrumentedConn struct {
+	driver.Conn
+	metrics *metrics.Metrics
+}
+
+func wrapConn(conn driver.Conn, m *metrics.Metrics) driver.Conn {
+	return &instrumentedConn{Conn: conn, metrics: m}
+}
+
+var (
+	_ driver.Pinger             = (*instrumentedConn)(nil)
+	_ driver.Queryer            = (*instrumentedConn)(nil) //nolint:staticcheck
+	_ driver.QueryerContext     = (*instrumentedConn)(nil)
+	_ driver.Execer             = (*instrumentedConn)(nil) //nolint:staticcheck
+	_ driver.ExecerContext      = (*instrumentedConn)(nil)
+	_ driver.ConnPrepareContext = (*instrumentedConn)(nil)
+	_ driver.ConnBeginTx        = (*instrumentedConn)(nil)
+	_ driver.SessionResetter    = (*instrumentedConn)(nil)
+	_ driver.NamedValueChecker  = (*instrumentedConn)(nil)
+	_ driver.Validator          = (*instrumentedConn)(nil)
+)
+
+func (c *instrumentedConn) Ping(ctx context.Context) error {
+	pinger, ok := c.Conn.(driver.Pinger)
+	if !ok {
+		return nil
+	}
+	return pinger.Ping(ctx)
+}
+
+func (c *instrumentedConn) Query(query string, args []driver.Value) (driver.Rows, error) { //nolint:staticcheck
+	queryer, ok := c.Conn.(driver.Queryer) //nolint:staticcheck
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	return queryer.Query(query, args)
+}
+
+func (c *instrumentedConn) QueryContext(
+	ctx context.Context, query string, args []driver.NamedValue,
+) (driver.Rows, error) {
+	queryer, ok := c.Conn.(driver.QueryerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	op := metrics.DatabaseOperation(query)
+	start := time.Now()
+	rows, err := queryer.QueryContext(ctx, query, args)
+	if err != nil {
+		c.metrics.DatabaseQueryFailed(op)
+		return rows, err
+	}
+	c.metrics.DatabaseQuerySucceeded(op, start)
+	return rows, nil
+}
+
+func (c *instrumentedConn) Exec(query string, args []driver.Value) (driver.Result, error) { //nolint:staticcheck
+	execer, ok := c.Conn.(driver.Execer) //nolint:staticcheck
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	return execer.Exec(query, args)
+}
+
+func (c *instrumentedConn) ExecContext(
+	ctx context.Context, query string, args []driver.NamedValue,
+) (driver.Result, error) {
+	execer, ok := c.Conn.(driver.ExecerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	op := metrics.DatabaseOperation(query)
+	start := time.Now()
+	res, err := execer.ExecContext(ctx, query, args)
+	if err != nil {
+		c.metrics.DatabaseQueryFailed(op)
+		return res, err
+	}
+	c.metrics.DatabaseQuerySucceeded(op, start)
+	return res, nil
+}
+
+// PrepareContext mirrors the fallback database/sql itself would perform if
+// the wrapped conn didn't support ConnPrepareContext: call the required
+// Prepare method and honor ctx cancellation. Adapted from
+// https://github.com/XSAM/otelsql (conn.go), which credits it to
+// database/sql's own ctxutil.go.
+func (c *instrumentedConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	if preparer, ok := c.Conn.(driver.ConnPrepareContext); ok {
+		return preparer.PrepareContext(ctx, query)
+	}
+
+	stmt, err := c.Conn.Prepare(query)
+	if err != nil {
+		return nil, err
+	}
+	select {
+	default:
+	case <-ctx.Done():
+		_ = stmt.Close()
+		return nil, ctx.Err()
+	}
+	return stmt, nil
+}
+
+// BeginTx mirrors the fallback database/sql itself would perform if the
+// wrapped conn didn't support ConnBeginTx. Adapted from
+// https://github.com/XSAM/otelsql (conn.go), which credits it to
+// database/sql's own ctxutil.go.
+func (c *instrumentedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if connBeginTx, ok := c.Conn.(driver.ConnBeginTx); ok {
+		return connBeginTx.BeginTx(ctx, opts)
+	}
+
+	if opts.Isolation != driver.IsolationLevel(sql.LevelDefault) {
+		return nil, errors.New("sql: driver does not support non-default isolation level")
+	}
+	if opts.ReadOnly {
+		return nil, errors.New("sql: driver does not support read-only transactions")
+	}
+
+	tx, err := c.Conn.Begin() //nolint:staticcheck
+	if err != nil {
+		return nil, err
+	}
+	if ctx.Done() != nil {
+		select {
+		default:
+		case <-ctx.Done():
+			_ = tx.Rollback()
+			return nil, ctx.Err()
+		}
+	}
+	return tx, nil
+}
+
+func (c *instrumentedConn) ResetSession(ctx context.Context) error {
+	sessionResetter, ok := c.Conn.(driver.SessionResetter)
+	if !ok {
+		return nil
+	}
+	return sessionResetter.ResetSession(ctx)
+}
+
+func (c *instrumentedConn) CheckNamedValue(nv *driver.NamedValue) error {
+	checker, ok := c.Conn.(driver.NamedValueChecker)
+	if !ok {
+		return driver.ErrSkip
+	}
+	return checker.CheckNamedValue(nv)
+}
+
+func (c *instrumentedConn) IsValid() bool {
+	if v, ok := c.Conn.(driver.Validator); ok {
+		return v.IsValid()
+	}
+	return true
+}

--- a/internal/database/instrumented_test.go
+++ b/internal/database/instrumented_test.go
@@ -1,0 +1,143 @@
+package database
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"github.com/open-policy-agent/opa-control-plane/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// fakeConn is a minimal driver.Conn (Prepare/Close/Begin only). The
+// combinator types below each additionally implement one specific optional
+// interface, so tests can verify instrumentedConn behaves correctly whether
+// or not the wrapped conn supports a given capability.
+type fakeConn struct {
+	failNext bool
+}
+
+func (*fakeConn) Prepare(string) (driver.Stmt, error) { return nil, errors.New("not implemented") }
+func (*fakeConn) Close() error                        { return nil }
+func (*fakeConn) Begin() (driver.Tx, error)           { return nil, errors.New("not implemented") }
+
+type fakeConnQueryerExecer struct{ *fakeConn }
+
+func (c fakeConnQueryerExecer) QueryContext(
+	context.Context, string, []driver.NamedValue,
+) (driver.Rows, error) {
+	if c.failNext {
+		return nil, errors.New("boom")
+	}
+	return nil, nil
+}
+
+func (c fakeConnQueryerExecer) ExecContext(
+	context.Context, string, []driver.NamedValue,
+) (driver.Result, error) {
+	if c.failNext {
+		return nil, errors.New("boom")
+	}
+	return driver.RowsAffected(1), nil
+}
+
+type fakeConnPinger struct{ *fakeConn }
+
+func (fakeConnPinger) Ping(context.Context) error { return nil }
+
+func TestInstrumentedConn_FallsBackWhenUnsupported(t *testing.T) {
+	// Neither QueryContext nor ExecContext are implemented by the plain
+	// fakeConn, so instrumentedConn must report ErrSkip (not silently
+	// succeed, and not panic) so database/sql knows to fall back.
+	m := metrics.New(metrics.Options{Registerer: prometheus.NewRegistry()})
+	wrapped := wrapConn(&fakeConn{}, m)
+
+	if _, err := wrapped.(driver.QueryerContext).QueryContext(context.Background(), "SELECT 1", nil); !errors.Is(err, driver.ErrSkip) {
+		t.Fatalf("QueryContext error = %v, want driver.ErrSkip", err)
+	}
+	if _, err := wrapped.(driver.ExecerContext).ExecContext(context.Background(), "INSERT INTO t VALUES (1)", nil); !errors.Is(err, driver.ErrSkip) {
+		t.Fatalf("ExecContext error = %v, want driver.ErrSkip", err)
+	}
+}
+
+func TestInstrumentedConn_ForwardsUnrelatedOptionalInterfaces(t *testing.T) {
+	// Pinger is never touched by our wrapper's metrics logic; verify it's
+	// still forwarded to the wrapped conn.
+	m := metrics.New(metrics.Options{Registerer: prometheus.NewRegistry()})
+	inner := fakeConnPinger{&fakeConn{}}
+
+	wrapped := wrapConn(inner, m)
+	if err := wrapped.(driver.Pinger).Ping(context.Background()); err != nil {
+		t.Fatalf("expected Ping to be forwarded to the wrapped conn, got error: %v", err)
+	}
+}
+
+func TestInstrumentedConn_RecordsMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := metrics.New(metrics.Options{Registerer: reg})
+
+	base := &fakeConn{}
+	wrapped := wrapConn(fakeConnQueryerExecer{base}, m)
+
+	if _, err := wrapped.(driver.QueryerContext).QueryContext(context.Background(), "SELECT 1", nil); err != nil {
+		t.Fatal(err)
+	}
+	base.failNext = true
+	if _, err := wrapped.(driver.ExecerContext).ExecContext(context.Background(), "INSERT INTO t VALUES (1)", nil); err == nil {
+		t.Fatal("expected error")
+	}
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var found bool
+	for _, f := range families {
+		if f.GetName() != "ocp_database_query_count_total" {
+			continue
+		}
+		found = true
+		var sawSuccess, sawFailure bool
+		for _, metric := range f.GetMetric() {
+			labels := map[string]string{}
+			for _, l := range metric.GetLabel() {
+				labels[l.GetName()] = l.GetValue()
+			}
+			switch {
+			case labels["operation"] == "select" && labels["state"] == "SUCCESS":
+				sawSuccess = true
+			case labels["operation"] == "insert" && labels["state"] == "FAILED":
+				sawFailure = true
+			}
+		}
+		if !sawSuccess {
+			t.Error("expected a select/SUCCESS sample")
+		}
+		if !sawFailure {
+			t.Error("expected an insert/FAILED sample")
+		}
+	}
+	if !found {
+		t.Fatal("expected ocp_database_query_count_total to be registered")
+	}
+}
+
+func TestInstrumentedConn_BeginTxFallback(t *testing.T) {
+	m := metrics.New(metrics.Options{Registerer: prometheus.NewRegistry()})
+	wrapped := wrapConn(&fakeConn{}, m)
+
+	// fakeConn.Begin always errors; BeginTx with default options should fall
+	// back to calling it and propagate the error (not panic or hang).
+	_, err := wrapped.(driver.ConnBeginTx).BeginTx(context.Background(), driver.TxOptions{})
+	if err == nil {
+		t.Fatal("expected an error propagated from the fallback Begin() call")
+	}
+
+	// Non-default isolation level isn't supported by the fallback path.
+	_, err = wrapped.(driver.ConnBeginTx).BeginTx(context.Background(), driver.TxOptions{Isolation: 1})
+	if err == nil {
+		t.Fatal("expected an error for unsupported isolation level")
+	}
+}

--- a/internal/metrics/init.go
+++ b/internal/metrics/init.go
@@ -21,6 +21,7 @@ func Init(cfg *config.MetricsConfig, reg prometheus.Registerer) *pkgmetrics.Metr
 		opts.HTTPEnabled = &disabled
 		opts.GitSyncEnabled = &disabled
 		opts.WorkerEnabled = &disabled
+		opts.DatabaseEnabled = &disabled
 		return pkgmetrics.New(opts)
 	}
 
@@ -47,6 +48,15 @@ func Init(cfg *config.MetricsConfig, reg prometheus.Registerer) *pkgmetrics.Metr
 		if cfg.Worker.BundleBuildDuration != nil {
 			opts.BundleBuildDurationEnabled = cfg.Worker.BundleBuildDuration.Enabled
 			opts.BundleBuildDurationBuckets = cfg.Worker.BundleBuildDuration.GetBuckets()
+		}
+	}
+
+	if cfg.Database != nil {
+		opts.DatabaseEnabled = cfg.Database.Enabled
+		opts.DatabaseQueryCountEnabled = cfg.Database.GetCountEnabled()
+		if cfg.Database.DatabaseQueryDuration != nil {
+			opts.DatabaseQueryDurationEnabled = cfg.Database.DatabaseQueryDuration.Enabled
+			opts.DatabaseQueryDurationBuckets = cfg.Database.DatabaseQueryDuration.GetBuckets()
 		}
 	}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -12,13 +12,15 @@ const DefaultNamespace = "ocp"
 
 // Metrics holds all registered Prometheus collectors.
 type Metrics struct {
-	gatherer            prometheus.Gatherer
-	durationHistogram   *prometheus.HistogramVec
-	gitSyncCount        *prometheus.CounterVec
-	gitSyncServerError  *prometheus.CounterVec
-	gitSyncDuration     *prometheus.HistogramVec
-	bundleBuildCount    *prometheus.CounterVec
-	bundleBuildDuration *prometheus.HistogramVec
+	gatherer              prometheus.Gatherer
+	durationHistogram     *prometheus.HistogramVec
+	gitSyncCount          *prometheus.CounterVec
+	gitSyncDuration       *prometheus.HistogramVec
+	bundleBuildCount      *prometheus.CounterVec
+	bundleBuildDuration   *prometheus.HistogramVec
+	databaseQueryCount    *prometheus.CounterVec
+	databaseQueryDuration *prometheus.HistogramVec
+	gitSyncServerError    *prometheus.CounterVec
 }
 
 // Options configures collector creation and registration.
@@ -42,6 +44,12 @@ type Options struct {
 	BundleBuildCountEnabled    *bool
 	BundleBuildDurationEnabled *bool
 	BundleBuildDurationBuckets []float64
+
+	// Database query metrics.
+	DatabaseEnabled              *bool
+	DatabaseQueryCountEnabled    *bool
+	DatabaseQueryDurationEnabled *bool
+	DatabaseQueryDurationBuckets []float64
 }
 
 // New builds and registers all enabled collectors against opts.Registerer and
@@ -60,6 +68,7 @@ func New(opts Options) *Metrics {
 	initHTTPMetrics(m, opts)
 	initGitSyncMetrics(m, opts)
 	initWorkerMetrics(m, opts)
+	initDatabaseMetrics(m, opts)
 	return m
 }
 

--- a/pkg/metrics/metrics_database.go
+++ b/pkg/metrics/metrics_database.go
@@ -1,0 +1,81 @@
+package metrics
+
+import (
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var defaultDatabaseQueryBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+func initDatabaseMetrics(m *Metrics, opts Options) {
+	if !isEnabled(opts.DatabaseEnabled) {
+		return
+	}
+
+	if isEnabled(opts.DatabaseQueryCountEnabled) {
+		m.databaseQueryCount = promauto.With(opts.Registerer).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: opts.Namespace,
+				Name:      "database_query_count_total",
+				Help:      "Number of database queries performed and their outcome",
+			},
+			[]string{"operation", "state"},
+		)
+	}
+
+	if !isEnabled(opts.DatabaseQueryDurationEnabled) {
+		return
+	}
+
+	m.databaseQueryDuration = promauto.With(opts.Registerer).NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: opts.Namespace,
+			Name:      "database_query_duration_seconds",
+			Help:      "Database query duration in seconds",
+			Buckets:   buckets(opts.DatabaseQueryDurationBuckets, defaultDatabaseQueryBuckets),
+		},
+		[]string{"operation"},
+	)
+}
+
+func (m *Metrics) DatabaseQueryFailed(operation string) {
+	if m == nil || m.databaseQueryCount == nil {
+		return
+	}
+	m.databaseQueryCount.WithLabelValues(operation, "FAILED").Inc()
+}
+
+func (m *Metrics) DatabaseQuerySucceeded(operation string, startTime time.Time) {
+	if m == nil || m.databaseQueryCount == nil {
+		return
+	}
+	m.databaseQueryCount.WithLabelValues(operation, "SUCCESS").Inc()
+	if m.databaseQueryDuration != nil {
+		m.databaseQueryDuration.WithLabelValues(operation).Observe(float64(time.Since(startTime).Seconds()))
+	}
+}
+
+// DatabaseOperation extracts a coarse operation label (e.g. "select",
+// "insert") from a SQL statement's first keyword, for use as the "operation"
+// label above. Unrecognized or multi-statement input all collapse to
+// "other" so the label set stays bounded regardless of query text.
+func DatabaseOperation(sql string) string {
+	knownOperations := map[string]bool{
+		"select": true, "insert": true, "update": true, "delete": true,
+		"begin": true, "commit": true, "rollback": true, "savepoint": true,
+		"release": true, "pragma": true, "create": true, "alter": true, "drop": true,
+	}
+
+	fields := strings.Fields(sql)
+	if len(fields) == 0 {
+		return "other"
+	}
+	op := strings.ToLower(fields[0])
+	if knownOperations[op] {
+		return op
+	}
+	return "other"
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -19,6 +19,8 @@ func TestNilMetricsSafe(t *testing.T) {
 	m.GitSyncSucceeded("src", "repo", time.Now())
 	m.BundleBuildFailed("b", "FAILED")
 	m.BundleBuildSucceeded("b", "SUCCESS", time.Now())
+	m.DatabaseQueryFailed("select")
+	m.DatabaseQuerySucceeded("select", time.Now())
 	if m.Handler() == nil {
 		t.Error("Handler() on nil Metrics must return a non-nil fallback")
 	}
@@ -34,14 +36,17 @@ func TestDisable(t *testing.T) {
 		{
 			name: "all subsystems",
 			opts: Options{
-				HTTPEnabled:    boolPtr(false),
-				GitSyncEnabled: boolPtr(false),
-				WorkerEnabled:  boolPtr(false),
+				HTTPEnabled:     boolPtr(false),
+				GitSyncEnabled:  boolPtr(false),
+				WorkerEnabled:   boolPtr(false),
+				DatabaseEnabled: boolPtr(false),
 			},
 			wantNil: []func(*Metrics) bool{
 				func(m *Metrics) bool { return m.durationHistogram == nil },
 				func(m *Metrics) bool { return m.gitSyncCount == nil },
 				func(m *Metrics) bool { return m.bundleBuildCount == nil },
+				func(m *Metrics) bool { return m.databaseQueryCount == nil },
+				func(m *Metrics) bool { return m.databaseQueryDuration == nil },
 			},
 		},
 		{
@@ -52,6 +57,31 @@ func TestDisable(t *testing.T) {
 				func(m *Metrics) bool { return m.gitSyncServerError == nil },
 				func(m *Metrics) bool { return m.gitSyncDuration == nil },
 				func(m *Metrics) bool { return m.durationHistogram != nil }, // others unaffected
+			},
+		},
+		{
+			name: "database subsystem",
+			opts: Options{DatabaseEnabled: boolPtr(false)},
+			wantNil: []func(*Metrics) bool{
+				func(m *Metrics) bool { return m.databaseQueryCount == nil },
+				func(m *Metrics) bool { return m.databaseQueryDuration == nil },
+				func(m *Metrics) bool { return m.durationHistogram != nil }, // others unaffected
+			},
+		},
+		{
+			name: "database query count only",
+			opts: Options{DatabaseQueryCountEnabled: boolPtr(false)},
+			wantNil: []func(*Metrics) bool{
+				func(m *Metrics) bool { return m.databaseQueryCount == nil },
+				func(m *Metrics) bool { return m.databaseQueryDuration != nil },
+			},
+		},
+		{
+			name: "database query duration only",
+			opts: Options{DatabaseQueryDurationEnabled: boolPtr(false)},
+			wantNil: []func(*Metrics) bool{
+				func(m *Metrics) bool { return m.databaseQueryDuration == nil },
+				func(m *Metrics) bool { return m.databaseQueryCount != nil },
 			},
 		},
 	}
@@ -87,6 +117,39 @@ func TestGitSyncRecording(t *testing.T) {
 	}
 }
 
+func TestDatabaseQueryRecording(t *testing.T) {
+	m := New(Options{Registerer: prometheus.NewRegistry()})
+
+	m.DatabaseQueryFailed("insert")
+	m.DatabaseQueryFailed("insert")
+	m.DatabaseQuerySucceeded("select", time.Now())
+
+	if got := testutil.ToFloat64(m.databaseQueryCount.WithLabelValues("insert", "FAILED")); got != 2 {
+		t.Errorf("FAILED count: want 2, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.databaseQueryCount.WithLabelValues("select", "SUCCESS")); got != 1 {
+		t.Errorf("SUCCESS count: want 1, got %v", got)
+	}
+}
+
+func TestDatabaseOperation(t *testing.T) {
+	cases := []struct {
+		sql  string
+		want string
+	}{
+		{"SELECT * FROM t", "select"},
+		{"insert into t values (1)", "insert"},
+		{"  UPDATE t SET x = 1", "update"},
+		{"", "other"},
+		{"WITH cte AS (SELECT 1) SELECT * FROM cte", "other"},
+	}
+	for _, tc := range cases {
+		if got := DatabaseOperation(tc.sql); got != tc.want {
+			t.Errorf("DatabaseOperation(%q) = %q, want %q", tc.sql, got, tc.want)
+		}
+	}
+}
+
 // TestNamespace verifies the fully-qualified metric names are derived from the
 // configured Namespace prefix: the default preserves the historical "ocp_"
 // names, and a custom prefix remaps them.
@@ -102,6 +165,8 @@ func TestNamespace(t *testing.T) {
 			want: []string{
 				"ocp_git_sync_count_total",
 				"ocp_git_sync_duration_seconds",
+				"ocp_database_query_count_total",
+				"ocp_database_query_duration_seconds",
 			},
 		},
 		{
@@ -110,6 +175,8 @@ func TestNamespace(t *testing.T) {
 			want: []string{
 				"build_worker_git_sync_count_total",
 				"build_worker_git_sync_duration_seconds",
+				"build_worker_database_query_count_total",
+				"build_worker_database_query_duration_seconds",
 			},
 		},
 	}
@@ -120,6 +187,7 @@ func TestNamespace(t *testing.T) {
 
 			// Observe once so the vec metric families are emitted by Gather.
 			m.GitSyncSucceeded("s1", "repo1", time.Now())
+			m.DatabaseQuerySucceeded("select", time.Now())
 
 			mfs, err := reg.Gather()
 			if err != nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -164,6 +164,7 @@ func (s *Service) WithAuthorizer(a ext_authz.Authorizer) *Service {
 
 func (s *Service) WithMetrics(m *metrics.Metrics) *Service {
 	s.metrics = m
+	s.database = *s.database.WithMetrics(m)
 	return s
 }
 

--- a/schema.json
+++ b/schema.json
@@ -122,6 +122,24 @@
       },
       "type": "object"
     },
+    "ConfigDatabaseMetrics": {
+      "additionalProperties": false,
+      "properties": {
+        "database_query_count": {
+          "$ref": "#/definitions/ConfigCounterConfig"
+        },
+        "database_query_duration": {
+          "$ref": "#/definitions/ConfigHistogramConfig"
+        },
+        "enabled": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "ConfigDatasource": {
       "additionalProperties": false,
       "properties": {
@@ -304,6 +322,9 @@
     "ConfigMetricsConfig": {
       "additionalProperties": false,
       "properties": {
+        "database": {
+          "$ref": "#/definitions/ConfigDatabaseMetrics"
+        },
         "enabled": {
           "type": [
             "null",


### PR DESCRIPTION
## Summary
Adds per-query Prometheus metrics for the `Database` layer (CockroachDB/postgres/mysql), which currently has none. Build-time DB failures today only surface as `BundleBuilderTaskFailureRateHigh{error_type=service}` (in a consumer) with no further detail on which query or operation failed.

New metrics, following the existing `gitsync`/`http`/`worker` pattern in `internal/metrics`:
- `ocp_database_query_count_total{operation, state}` — counter, `state` is `SUCCESS`/`FAILED`
- `ocp_database_query_duration_seconds{operation}` — histogram, `operation` parsed from the SQL statement's first keyword (select/insert/update/...)

## Design

The instrumentation is wired in at the `driver.Connector` level (`internal/database/instrumented.go`), not by touching any of the ~50 methods in `database.go` — every one of them already funnels through `sql.OpenDB(connector)` for postgres/CockroachDB/mysql (sqlite's `sql.Open` path is left alone; it's the in-memory/dev default, not a production case).

The tricky part of this kind of wrapping is `driver.Conn`'s several *optional* interfaces (`QueryerContext`, `ExecerContext`, `Pinger`, `ConnPrepareContext`, `ConnBeginTx`, `SessionResetter`, `NamedValueChecker`, `Validator`) — `database/sql` detects which ones a `Conn` implements to decide its execution path, and a wrapper that doesn't preserve the same set of capabilities silently changes behavior (e.g. falling back to a slower prepare-then-exec path) without erroring.

An earlier version of this PR tried to solve this by constructing a different wrapper type per detected capability combination. `TestInstrumentedConn_ForwardsUnrelatedOptionalInterfaces` caught a real bug in that approach (`driver.Pinger` support silently dropped), which led to redesigning around the pattern used by [`github.com/XSAM/otelsql`](https://github.com/XSAM/otelsql) (not taken as a dependency — it's OTel-native, this stays Prometheus-native to match the rest of `internal/metrics`): the wrapper unconditionally implements every optional interface, and each method checks at call time whether the wrapped conn actually supports it, returning `driver.ErrSkip` when it doesn't — the sentinel `database/sql` defines for exactly this case, so it falls back exactly as it would without any wrapping. This avoids the combinatorial-type problem entirely: there's one wrapper type, and no capability can be silently dropped.

`PrepareContext`/`BeginTx` fallback logic (used when the wrapped conn doesn't implement the optional context-aware version) is adapted from `otelsql`, which itself credits it to `database/sql`'s own internal `ctxutil.go`.

## Wiring
`Database.WithMetrics(*metrics.Metrics)` mirrors the existing `WithLogger`/`WithAuthorizer` pattern. `Service.WithMetrics` now also propagates to `s.database`, mirroring how it already does for `WithLogger`.

Also adds `DatabaseMetrics` to the public `MetricsConfig` schema (`internal/config/config.go`, regenerated `schema.json`/`config/schema.json`) for parity with `GitSyncMetrics`/`WorkerMetrics`/`HTTPMetrics`, so operators can fine-tune or disable it the same way.

## Test plan
- `TestInstrumentedConn_FallsBackWhenUnsupported` — wrapping a conn with neither `QueryerContext` nor `ExecerContext` returns `driver.ErrSkip`, not a panic or a silent no-op.
- `TestInstrumentedConn_ForwardsUnrelatedOptionalInterfaces` — `driver.Pinger` support is preserved through the wrapper (the regression test for the bug the earlier design had).
- `TestInstrumentedConn_RecordsMetrics` — a successful query and a failed exec both show up correctly in `ocp_database_query_count_total` via a real `prometheus.Registry`.
- `TestInstrumentedConn_BeginTxFallback` — the `ctxutil.go`-derived fallback path propagates errors correctly and rejects unsupported non-default isolation levels.
- `go test ./internal/database/... ./internal/metrics/... ./internal/config/...` — all pass except the pre-existing `postgres`/`mysql`/`cockroachdb` testcontainers-based subtests, which fail in my sandbox with "rootless Docker not found" — confirmed this also fails identically on unmodified `main`, so it's an environment limitation, not something this PR broke. Would appreciate a maintainer or CI run to confirm this actually instruments real CockroachDB/postgres/mysql connections end-to-end, since that's the one thing my sandbox couldn't verify directly.
