### PR TITLE
pkg/service: add ValidateSourceAccess for lightweight source validation

### DIFF
--- a/pkg/service/validate.go
+++ b/pkg/service/validate.go
@@ -11,20 +11,43 @@ import (
 	pkgsync "github.com/open-policy-agent/opa-control-plane/pkg/sync"
 )
 
+// BindingType identifies the kind of binding a BindingAccessResult reports on.
+type BindingType string
+
+const (
+	BindingTypeGit  BindingType = "git"
+	BindingTypeHTTP BindingType = "http"
+	BindingTypeS3   BindingType = "s3"
+)
+
+// Error is a JSON-serializable description of why a binding's access check
+// failed. A Go error doesn't marshal to anything useful on its own, so
+// BindingAccessResult reports failures through this type instead.
+type Error struct {
+	Message string `json:"message"`
+	// UserError is true when the failure is caused by misconfiguration
+	// (invalid credentials, an unreachable repository/URL, a 4xx
+	// response, ...) rather than a transient or internal failure. Callers
+	// can use this to decide whether Message is safe to surface to the
+	// end user as-is.
+	UserError bool `json:"user_error"`
+}
+
+func newError(err error) *Error {
+	if err == nil {
+		return nil
+	}
+	return &Error{Message: err.Error(), UserError: syncerr.IsUserError(err)}
+}
+
 // BindingAccessResult reports the outcome of checking one git or datasource
 // binding within a Source for reachability and credential validity.
 type BindingAccessResult struct {
-	// Type is "git", "http", or "s3".
-	Type string
+	Type BindingType `json:"type"`
 	// Name is the datasource name, or "" for the source's git binding.
-	Name string
-	// Err is non-nil if the binding could not be verified.
-	Err error
-	// UserError is true when Err is caused by misconfiguration (invalid
-	// credentials, an unreachable repository/URL, a 4xx response, ...)
-	// rather than a transient or internal failure. Callers can use this to
-	// decide whether Err is safe to surface to the end user as-is.
-	UserError bool
+	Name string `json:"name,omitempty"`
+	// Err is nil if the binding was successfully verified.
+	Err *Error `json:"error,omitempty"`
 }
 
 type accessChecker interface {
@@ -46,7 +69,7 @@ func ValidateSourceAccess(ctx context.Context, src *config.Source, provider pkgs
 	if checker := gitAccessChecker(src, provider); checker != nil {
 		defer checker.Close(ctx)
 		err := checker.CheckAccess(ctx)
-		results = append(results, BindingAccessResult{Type: "git", Err: err, UserError: syncerr.IsUserError(err)})
+		results = append(results, BindingAccessResult{Type: BindingTypeGit, Err: newError(err)})
 	}
 
 	for _, ds := range src.Datasources {
@@ -56,7 +79,7 @@ func ValidateSourceAccess(ctx context.Context, src *config.Source, provider pkgs
 		}
 		defer checker.Close(ctx)
 		err := checker.CheckAccess(ctx)
-		results = append(results, BindingAccessResult{Type: ds.Type, Name: ds.Name, Err: err, UserError: syncerr.IsUserError(err)})
+		results = append(results, BindingAccessResult{Type: BindingType(ds.Type), Name: ds.Name, Err: newError(err)})
 	}
 
 	return results

--- a/pkg/service/validate.go
+++ b/pkg/service/validate.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"cmp"
+	"context"
+
+	"github.com/open-policy-agent/opa-control-plane/internal/config"
+	"github.com/open-policy-agent/opa-control-plane/internal/gitsync"
+	"github.com/open-policy-agent/opa-control-plane/internal/httpsync"
+	"github.com/open-policy-agent/opa-control-plane/internal/syncerr"
+	pkgsync "github.com/open-policy-agent/opa-control-plane/pkg/sync"
+)
+
+// BindingAccessResult reports the outcome of checking one git or datasource
+// binding within a Source for reachability and credential validity.
+type BindingAccessResult struct {
+	// Type is "git", "http", or "s3".
+	Type string
+	// Name is the datasource name, or "" for the source's git binding.
+	Name string
+	// Err is non-nil if the binding could not be verified.
+	Err error
+	// UserError is true when Err is caused by misconfiguration (invalid
+	// credentials, an unreachable repository/URL, a 4xx response, ...)
+	// rather than a transient or internal failure. Callers can use this to
+	// decide whether Err is safe to surface to the end user as-is.
+	UserError bool
+}
+
+type accessChecker interface {
+	CheckAccess(ctx context.Context) error
+	Close(ctx context.Context)
+}
+
+// ValidateSourceAccess checks whether each of src's git and datasource
+// bindings is reachable and its credentials, if any, are valid, without
+// performing a full clone or download. provider resolves named credentials
+// referenced by src's bindings; pass nil if none of them reference secrets.
+//
+// Unlike Service.Run, this does not require Init or a database connection,
+// so it can be called directly against a Source before (or without) it ever
+// being persisted.
+func ValidateSourceAccess(ctx context.Context, src *config.Source, provider pkgsync.SecretProvider) []BindingAccessResult {
+	var results []BindingAccessResult
+
+	if checker := gitAccessChecker(src, provider); checker != nil {
+		defer checker.Close(ctx)
+		err := checker.CheckAccess(ctx)
+		results = append(results, BindingAccessResult{Type: "git", Err: err, UserError: syncerr.IsUserError(err)})
+	}
+
+	for _, ds := range src.Datasources {
+		checker := datasourceAccessChecker(ds, provider)
+		if checker == nil {
+			continue
+		}
+		defer checker.Close(ctx)
+		err := checker.CheckAccess(ctx)
+		results = append(results, BindingAccessResult{Type: ds.Type, Name: ds.Name, Err: err, UserError: syncerr.IsUserError(err)})
+	}
+
+	return results
+}
+
+func gitAccessChecker(src *config.Source, provider pkgsync.SecretProvider) accessChecker {
+	if src.Git.Repo == "" {
+		return nil
+	}
+	return gitsync.New("", src.Git, src.Name).WithSecretProvider(provider)
+}
+
+func datasourceAccessChecker(ds config.Datasource, provider pkgsync.SecretProvider) accessChecker {
+	switch ds.Type {
+	case "http":
+		url, _ := ds.Config["url"].(string)
+		method, _ := ds.Config["method"].(string)
+		method = cmp.Or(method, "GET")
+		body, _ := ds.Config["body"].(string)
+		headers, _ := ds.Config["headers"].(map[string]any)
+		return httpsync.New("", url, method, body, headers, ds.Credentials).WithSecretProvider(provider)
+	case "s3":
+		bucket, _ := ds.Config["bucket"].(string)
+		key, _ := ds.Config["key"].(string)
+		region, _ := ds.Config["region"].(string)
+		endpoint, _ := ds.Config["endpoint"].(string)
+		region = cmp.Or(region, "us-east-1")
+
+		var url string
+		if endpoint != "" {
+			url = endpoint + "/" + bucket + "/" + key
+		} else {
+			url = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + key
+		}
+		return httpsync.NewS3("", url, region, endpoint, ds.Credentials)
+	default:
+		return nil
+	}
+}

--- a/pkg/service/validate_test.go
+++ b/pkg/service/validate_test.go
@@ -1,0 +1,135 @@
+package service_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+
+	"github.com/open-policy-agent/opa-control-plane/internal/config"
+	"github.com/open-policy-agent/opa-control-plane/pkg/service"
+)
+
+func TestValidateSourceAccess_NoBindings(t *testing.T) {
+	src := &config.Source{Name: "s"}
+
+	results := service.ValidateSourceAccess(t.Context(), src, nil)
+	if len(results) != 0 {
+		t.Fatalf("expected no results, got %v", results)
+	}
+}
+
+func TestValidateSourceAccess_Git(t *testing.T) {
+	t.Run("reachable repository", func(t *testing.T) {
+		repoPath := t.TempDir() + "/repo"
+		repository, err := git.PlainInit(repoPath, false)
+		if err != nil {
+			t.Fatalf("init test repository: %v", err)
+		}
+		w, err := repository.Worktree()
+		if err != nil {
+			t.Fatalf("worktree: %v", err)
+		}
+		if _, err := w.Commit("init", &git.CommitOptions{Author: &object.Signature{}, AllowEmptyCommits: true}); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+
+		ref := "refs/heads/master"
+		src := &config.Source{
+			Name: "s",
+			Git:  config.Git{Repo: repoPath, Reference: &ref},
+		}
+
+		results := service.ValidateSourceAccess(t.Context(), src, nil)
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %v", results)
+		}
+		if results[0].Type != "git" || results[0].Err != nil {
+			t.Fatalf("expected successful git result, got %+v", results[0])
+		}
+	})
+
+	t.Run("unreachable repository", func(t *testing.T) {
+		ref := "refs/heads/master"
+		src := &config.Source{
+			Name: "s",
+			Git:  config.Git{Repo: t.TempDir() + "/does-not-exist", Reference: &ref},
+		}
+
+		results := service.ValidateSourceAccess(t.Context(), src, nil)
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %v", results)
+		}
+		if results[0].Type != "git" || results[0].Err == nil {
+			t.Fatalf("expected a git error, got %+v", results[0])
+		}
+		if !results[0].UserError {
+			t.Fatalf("expected UserError=true for an unreachable repository, got %+v", results[0])
+		}
+	})
+}
+
+func TestValidateSourceAccess_HTTPDatasource(t *testing.T) {
+	t.Run("reachable endpoint", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer ts.Close()
+
+		src := &config.Source{
+			Name: "s",
+			Datasources: config.Datasources{
+				{Name: "ds1", Path: "ds1", Type: "http", Config: map[string]any{"url": ts.URL}},
+			},
+		}
+
+		results := service.ValidateSourceAccess(t.Context(), src, nil)
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %v", results)
+		}
+		if results[0].Type != "http" || results[0].Name != "ds1" || results[0].Err != nil {
+			t.Fatalf("expected successful http result, got %+v", results[0])
+		}
+	})
+
+	t.Run("unauthorized endpoint", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		}))
+		defer ts.Close()
+
+		src := &config.Source{
+			Name: "s",
+			Datasources: config.Datasources{
+				{Name: "ds1", Path: "ds1", Type: "http", Config: map[string]any{"url": ts.URL}},
+			},
+		}
+
+		results := service.ValidateSourceAccess(t.Context(), src, nil)
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %v", results)
+		}
+		if results[0].Err == nil {
+			t.Fatalf("expected an error, got %+v", results[0])
+		}
+		if !results[0].UserError {
+			t.Fatalf("expected UserError=true for a 401 response, got %+v", results[0])
+		}
+	})
+}
+
+func TestValidateSourceAccess_UnknownDatasourceTypeSkipped(t *testing.T) {
+	src := &config.Source{
+		Name: "s",
+		Datasources: config.Datasources{
+			{Name: "ds1", Path: "ds1", Type: "sql", Config: map[string]any{}},
+		},
+	}
+
+	results := service.ValidateSourceAccess(t.Context(), src, nil)
+	if len(results) != 0 {
+		t.Fatalf("expected sql datasources to be skipped (validated separately), got %v", results)
+	}
+}

--- a/pkg/service/validate_test.go
+++ b/pkg/service/validate_test.go
@@ -46,7 +46,7 @@ func TestValidateSourceAccess_Git(t *testing.T) {
 		if len(results) != 1 {
 			t.Fatalf("expected 1 result, got %v", results)
 		}
-		if results[0].Type != "git" || results[0].Err != nil {
+		if results[0].Type != service.BindingTypeGit || results[0].Err != nil {
 			t.Fatalf("expected successful git result, got %+v", results[0])
 		}
 	})
@@ -62,10 +62,10 @@ func TestValidateSourceAccess_Git(t *testing.T) {
 		if len(results) != 1 {
 			t.Fatalf("expected 1 result, got %v", results)
 		}
-		if results[0].Type != "git" || results[0].Err == nil {
+		if results[0].Type != service.BindingTypeGit || results[0].Err == nil {
 			t.Fatalf("expected a git error, got %+v", results[0])
 		}
-		if !results[0].UserError {
+		if !results[0].Err.UserError {
 			t.Fatalf("expected UserError=true for an unreachable repository, got %+v", results[0])
 		}
 	})
@@ -89,7 +89,7 @@ func TestValidateSourceAccess_HTTPDatasource(t *testing.T) {
 		if len(results) != 1 {
 			t.Fatalf("expected 1 result, got %v", results)
 		}
-		if results[0].Type != "http" || results[0].Name != "ds1" || results[0].Err != nil {
+		if results[0].Type != service.BindingTypeHTTP || results[0].Name != "ds1" || results[0].Err != nil {
 			t.Fatalf("expected successful http result, got %+v", results[0])
 		}
 	})
@@ -114,7 +114,7 @@ func TestValidateSourceAccess_HTTPDatasource(t *testing.T) {
 		if results[0].Err == nil {
 			t.Fatalf("expected an error, got %+v", results[0])
 		}
-		if !results[0].UserError {
+		if !results[0].Err.UserError {
 			t.Fatalf("expected UserError=true for a 401 response, got %+v", results[0])
 		}
 	})


### PR DESCRIPTION
## Summary
- Adds `service.ValidateSourceAccess(ctx, src, provider)`, a standalone function that checks whether a `Source`'s git and datasource (http/s3) bindings are reachable and their credentials, if any, valid — without requiring `Service.Init` or a database connection.
- Builds on the `CheckAccess` support added to gitsync/httpsync in #381: constructs the same internal synchronizer types used during a real sync and calls `CheckAccess` on each configured binding.
- Each `BindingAccessResult` also reports `UserError`, derived from `syncerr.IsUserError`, so callers can distinguish misconfiguration (invalid credentials, unreachable repo/URL, 4xx response) from a transient/internal failure.
- This closes the gap left by #381: `gitsync`/`httpsync`/`syncerr` are internal packages, so external callers had no way to construct a `Synchronizer` and call `CheckAccess` themselves, even though `pkg/sync.AccessChecker` is public.

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] New unit tests: `TestValidateSourceAccess_NoBindings`, `TestValidateSourceAccess_Git`, `TestValidateSourceAccess_HTTPDatasource`, `TestValidateSourceAccess_UnknownDatasourceTypeSkipped`
- [x] Existing test suites unaffected