### PR TITLE
Track when bundle status was last updated

### DIFF
--- a/internal/database/bundle_status.go
+++ b/internal/database/bundle_status.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/open-policy-agent/opa-control-plane/pkg/config"
 )
@@ -39,8 +40,12 @@ func (d *Database) UpsertBundleStatus(ctx context.Context, tenant, bundle, revis
 			return fmt.Errorf("error looking up bundle %s: %w", bundle, err)
 		}
 
-		resID, err := d.upsertReturning(ctx, true, true, tx, tenant, "bundles_statuses", []string{"bundle_id", "revision", "phase", "status", "error_message"}, []string{"bundle_id", "revision"},
-			bundleID, revision, phase, status, errMsg)
+		// updated_at is written on every upsert so callers
+		// can tell when a status last changed.
+		now := time.Now().UTC()
+
+		resID, err := d.upsertReturning(ctx, true, true, tx, tenant, "bundles_statuses", []string{"bundle_id", "revision", "phase", "status", "error_message", "updated_at"}, []string{"bundle_id", "revision"},
+			bundleID, revision, phase, status, errMsg, now)
 		if err != nil {
 			return fmt.Errorf("error inserting bundle status: %w", err)
 		}
@@ -107,13 +112,13 @@ func (d *Database) GetBundleStatus(ctx context.Context, id int) (*config.BundleS
 	var s config.BundleStatus
 	err := tx1(ctx, d, func(tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx,
-			`SELECT id, tenant_id, bundle_id, revision, phase, status, error_message, created_at
+			`SELECT id, tenant_id, bundle_id, revision, phase, status, error_message, created_at, updated_at
 			 FROM bundles_statuses
 			 WHERE id = `+d.arg(0),
 			id,
 		).Scan(
 			&s.ID, &s.TenantID, &s.BundleID, &s.Revision, &s.Phase, &s.Status,
-			&s.ErrorMessage, &s.CreatedAt,
+			&s.ErrorMessage, &s.CreatedAt, &s.UpdatedAt,
 		)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
@@ -175,7 +180,7 @@ func (d *Database) ListBundleStatuses(ctx context.Context, principal, tenant, bu
 
 		if revision != "" {
 			query = fmt.Sprintf(
-				`SELECT bundles_statuses.id, tenant_id, bundle_id, revision, phase, status, error_message, created_at
+				`SELECT bundles_statuses.id, tenant_id, bundle_id, revision, phase, status, error_message, created_at, updated_at
 				 FROM bundles_statuses
 				 JOIN tenants ON tenants.id = bundles_statuses.tenant_id
 				 WHERE tenants.name = %s AND bundle_id = %s AND revision = %s
@@ -186,7 +191,7 @@ func (d *Database) ListBundleStatuses(ctx context.Context, principal, tenant, bu
 			args = []any{tenant, bundleID, revision, limit}
 		} else {
 			query = fmt.Sprintf(
-				`SELECT bundles_statuses.id, tenant_id, bundle_id, revision, phase, status, error_message, created_at
+				`SELECT bundles_statuses.id, tenant_id, bundle_id, revision, phase, status, error_message, created_at, updated_at
 				 FROM bundles_statuses
 				 JOIN tenants ON tenants.id = bundles_statuses.tenant_id
 				 WHERE tenants.name = %s AND bundle_id = %s
@@ -207,7 +212,7 @@ func (d *Database) ListBundleStatuses(ctx context.Context, principal, tenant, bu
 			var s config.BundleStatus
 			if err := rows.Scan(
 				&s.ID, &s.TenantID, &s.BundleID, &s.Revision, &s.Phase, &s.Status,
-				&s.ErrorMessage, &s.CreatedAt,
+				&s.ErrorMessage, &s.CreatedAt, &s.UpdatedAt,
 			); err != nil {
 				return fmt.Errorf("error scanning bundle status: %w", err)
 			}

--- a/internal/database/bundle_status_test.go
+++ b/internal/database/bundle_status_test.go
@@ -291,6 +291,10 @@ func TestInsertBundleStatusUpdateExisting(t *testing.T) {
 				id1, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-1", PhaseSyncBundle, StatusInProgress, "")
 				require.NoError(t, err)
 
+				first, err := db.GetBundleStatus(ctx, id1)
+				require.NoError(t, err)
+				assert.False(t, first.UpdatedAt.IsZero(), "updated_at should be set on insert")
+
 				// Insert second time with different phase/status - should update existing record
 				id2, err := db.UpsertBundleStatus(ctx, tenant, "bundle-a", "rev-1", PhaseBuildBundle, StatusInProgress, "")
 				require.NoError(t, err)
@@ -303,6 +307,9 @@ func TestInsertBundleStatusUpdateExisting(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, PhaseBuildBundle, status.Phase)
 				assert.Equal(t, StatusInProgress, status.Status)
+				// updated_at must advance on update, while created_at stays fixed.
+				assert.False(t, status.UpdatedAt.Before(first.UpdatedAt), "updated_at should not go backwards on update")
+				assert.Equal(t, first.CreatedAt, status.CreatedAt, "created_at should not change on update")
 			})
 		})
 	}
@@ -389,6 +396,7 @@ func TestGetBundleStatus(t *testing.T) {
 				assert.Equal(t, PhaseSyncBundle, status.Phase)
 				assert.Equal(t, StatusCompleted, status.Status)
 				assert.NotZero(t, status.CreatedAt)
+				assert.NotZero(t, status.UpdatedAt)
 			})
 
 			t.Run("get non-existent status returns ErrNotFound", func(t *testing.T) {

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -44,6 +44,7 @@ func Migrations(dialect string) (fs.FS, error) {
 		addDatasourcesCredentialsName(24, dialect),
 		addSourcesGitCredentialsName(25, dialect),
 		addBundlesStatuses(26, dialect),
+		addBundlesStatusesUpdatedAt(27, dialect), // adds 2, next is 29.
 	), nil
 }
 

--- a/internal/migrations/migrations_next.go
+++ b/internal/migrations/migrations_next.go
@@ -103,6 +103,23 @@ func addBundlesStatuses(offset int, dialect string) fs.FS {
 	})
 }
 
+// addBundlesStatusesUpdatedAt adds an updated_at column to bundles_statuses so
+// callers can tell when a status last changed.
+func addBundlesStatusesUpdatedAt(offset int, dialect string) fs.FS {
+	var stmtAdd string
+	switch dialect {
+	case "sqlite", "postgresql", "cockroachdb", "mysql":
+		stmtAdd = `ALTER TABLE bundles_statuses ADD updated_at TIMESTAMP`
+	}
+
+	stmtBackfill := `UPDATE bundles_statuses SET updated_at = created_at WHERE updated_at IS NULL`
+
+	return ocp_fs.MapFS(map[string]string{
+		fmt.Sprintf("%03d_add_bundles_statuses_updated_at.up.sql", offset):        stmtAdd,
+		fmt.Sprintf("%03d_backfill_bundles_statuses_updated_at.up.sql", offset+1): stmtBackfill,
+	})
+}
+
 // NOTE(sr): We create new tables to drop constraints. It's hard to predict constraint names
 // across MySQL and Postgres if they have not been set up at creation time.
 // NOTE(sr): We want this to work, or fail, in one step. So this will all be done in a single migration,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -198,6 +198,7 @@ type BundleStatus struct {
 	Status       string    `json:"status"`
 	ErrorMessage *string   `json:"error_message,omitempty"`
 	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
 
 	_ struct{} `additionalProperties:"false"`
 }


### PR DESCRIPTION
Currently OCP does not record any timing for status updates. Callers might find this timing information useful.

This change adds an updated_at column to bundles_statuses that is written on every upsert, and exposes it through the BundleStatus API type so callers can read it.