### PR TITLE
service: fix zero-value BuildState being misreported as INTERNAL_ERROR

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -81,7 +81,8 @@ type BuildState int
 type BuildPhase int
 
 const (
-	BuildStateInternalError BuildState = iota
+	BuildStateUnknown BuildState = iota
+	BuildStateInternalError
 	BuildStateConfigError
 	BuildStateSuccess
 	BuildStateSyncFailed
@@ -89,6 +90,7 @@ const (
 	BuildStateTransformFailed
 	BuildStateBuildFailed
 	BuildStatePushFailed
+	BuildStateCancelled
 )
 
 const (
@@ -100,6 +102,8 @@ const (
 
 func (s BuildState) String() string {
 	switch s {
+	case BuildStateInternalError:
+		return "INTERNAL_ERROR"
 	case BuildStateConfigError:
 		return "CONFIG_ERROR"
 	case BuildStateSuccess:
@@ -114,10 +118,10 @@ func (s BuildState) String() string {
 		return "BUILD_FAILED"
 	case BuildStatePushFailed:
 		return "PUSH_FAILED"
-	case BuildStateInternalError:
-		fallthrough
+	case BuildStateCancelled:
+		return "CANCELLED"
 	default:
-		return "INTERNAL_ERROR"
+		return "UNKNOWN"
 	}
 }
 

--- a/pkg/service/worker.go
+++ b/pkg/service/worker.go
@@ -43,6 +43,7 @@ type BundleWorker struct {
 	log           *logging.Logger
 	bar           *progress.Bar
 	status        Status
+	reported      bool
 	interval      time.Duration
 	database      *database.Database
 	tenant        string
@@ -256,20 +257,13 @@ func (w *BundleWorker) Execute(ctx context.Context) time.Time {
 
 func (w *BundleWorker) report(ctx context.Context, state BuildState, phase BuildPhase, revision string, startTime time.Time, err error) time.Time {
 	interval := w.interval
-	w.status.State = state
 	msg := ""
 	if err != nil {
 		interval = errorInterval // faster retry on error
 		msg = err.Error()
-		w.status.Message = msg
 	}
 
-	if w.database != nil {
-		if _, uerr := w.database.UpsertBundleStatus(ctx, w.tenant, w.bundleConfig.Name,
-			revision, phase.String(), state.String(), msg); uerr != nil {
-			w.log.Warnf("failed to track bundle status %q: %v", w.bundleConfig.Name, uerr)
-		}
-	}
+	w.writeStatus(ctx, state, phase, revision, msg)
 
 	if state == BuildStateSuccess {
 		w.metrics.BundleBuildSucceeded(w.bundleConfig.Name, state.String(), startTime)
@@ -282,6 +276,25 @@ func (w *BundleWorker) report(ctx context.Context, state BuildState, phase Build
 	}
 
 	return time.Now().Add(interval)
+}
+
+// writeStatus records the worker's current state in memory and, if a database
+// is configured, persists it as a bundle status row.
+//
+// It deliberately skips metrics and the retry interval, which report() drives
+// on top of this. That keeps it safe to call from die() too: a cancelled
+// worker is neither a failed nor a successful build, so it shouldn't affect
+// either.
+func (w *BundleWorker) writeStatus(ctx context.Context, state BuildState, phase BuildPhase, revision string, msg string) {
+	w.status = Status{State: state, Message: msg}
+	w.reported = true
+
+	if w.database != nil {
+		if _, uerr := w.database.UpsertBundleStatus(ctx, w.tenant, w.bundleConfig.Name,
+			revision, phase.String(), state.String(), msg); uerr != nil {
+			w.log.Warnf("failed to track bundle status %q: %v", w.bundleConfig.Name, uerr)
+		}
+	}
 }
 
 func (w *BundleWorker) changeConfiguration() {
@@ -302,6 +315,11 @@ func (w *BundleWorker) configurationChanged() bool {
 }
 
 func (w *BundleWorker) die(ctx context.Context) time.Time {
+	if !w.reported {
+		w.writeStatus(ctx, BuildStateCancelled, BuildPhaseSync, database.SentinelRevision,
+			"worker stopped due to a configuration change or shutdown before completing a build iteration")
+	}
+
 	for _, ss := range w.synchronizers {
 		ss.sync.Close(ctx)
 	}

--- a/pkg/service/worker_test.go
+++ b/pkg/service/worker_test.go
@@ -65,6 +65,87 @@ func TestBundleWorkerExecute_SyncError(t *testing.T) {
 	}
 }
 
+// TestBundleWorkerExecute_CancelledBeforeReport verifies that a worker which is
+// told to reconfigure/shutdown before it ever completes a build iteration is
+// reported as BuildStateCancelled rather than being left at the zero-value
+// BuildStateUnknown.
+func TestBundleWorkerExecute_CancelledBeforeReport(t *testing.T) {
+	worker := NewBundleWorker(t.TempDir(), &config.Bundle{Name: "test_bundle"}, nil, nil,
+		logging.NewLogger(logging.Config{}), progress.New(true, 1, "test")).
+		WithSingleShot(true)
+
+	// Simulate the worker being told to shut down/reconfigure before Execute
+	// ever runs, e.g. via Service.Run's final UpdateConfig(nil, nil, nil) call.
+	worker.UpdateConfig(nil, nil, nil)
+
+	worker.Execute(t.Context())
+
+	if worker.status.State != BuildStateCancelled {
+		t.Fatalf("expected state %v, got %v", BuildStateCancelled, worker.status.State)
+	}
+	if !worker.Done() {
+		t.Fatal("expected worker to be done")
+	}
+}
+
+// TestBundleWorkerExecute_CancelledBeforeReportPersisted verifies that a worker
+// cancelled before its first report() still persists a queryable CANCELLED
+// status row, instead of leaving the database with whatever the previous
+// build iteration wrote (or nothing at all).
+func TestBundleWorkerExecute_CancelledBeforeReportPersisted(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := migrations.New().
+		WithConfig(&config.Database{
+			SQL: &config.SQLDatabase{Driver: "sqlite3", DSN: dbs.MemoryDBName()},
+		}).
+		WithLogger(logging.NewLogger(logging.Config{})).
+		WithMigrate(true).Run(ctx)
+	if err != nil {
+		t.Fatalf("failed to init database: %v", err)
+	}
+	defer db.CloseDB()
+
+	const tenant = "default"
+	principal := database.Principal{Id: "admin", Role: "administrator", Tenant: tenant}
+	if err := db.UpsertPrincipal(ctx, principal); err != nil {
+		t.Fatal(err)
+	}
+
+	root := config.Root{
+		Bundles: map[string]*config.Bundle{
+			"test_bundle": {Name: "test_bundle"},
+		},
+		Database: &config.Database{SQL: &config.SQLDatabase{Driver: "sqlite3", DSN: database.SQLiteMemoryOnlyDSN}},
+	}
+	if err := root.Unmarshal(); err != nil {
+		t.Fatalf("failed to unmarshal config: %v", err)
+	}
+	if err := db.LoadConfig(ctx, nil, principal.Id, tenant, &root); err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	worker := NewBundleWorker(t.TempDir(), root.Bundles["test_bundle"], nil, nil,
+		logging.NewLogger(logging.Config{}), progress.New(true, 1, "test")).
+		WithSingleShot(true).
+		WithDatabase(db).
+		WithTenant(tenant)
+
+	worker.UpdateConfig(nil, nil, nil)
+	worker.Execute(ctx)
+
+	status, err := db.GetLatestBundleStatus(ctx, principal.Id, tenant, "test_bundle")
+	if err != nil {
+		t.Fatalf("expected a persisted status, got error: %v", err)
+	}
+	if status.Status != BuildStateCancelled.String() {
+		t.Fatalf("expected status %q, got %q", BuildStateCancelled.String(), status.Status)
+	}
+	if status.Revision != database.SentinelRevision {
+		t.Fatalf("expected sentinel revision %q, got %q", database.SentinelRevision, status.Revision)
+	}
+}
+
 // TestBundleWorkerExecute_SyncFailurePersisted verifies that a git-sync failure
 // produces a queryable SYNC_FAILED status row (persisted under the pre-revision
 // sentinel), proving report() centralizes the write for pre-revision phases.


### PR DESCRIPTION
## Summary
- `BuildStateInternalError` was defined as `BuildState`'s zero value, so any `BundleWorker` whose status was never populated via `report()` (e.g. it exits early through `die()` on a configuration change or shutdown before completing a build iteration) was misreported as `INTERNAL_ERROR` with an empty error message, even though no real error occurred.
- Adds `BuildStateUnknown` as the explicit zero value/state, and has `die()` mark the worker's status accordingly whenever it exits without ever calling `report()`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/service/...` (excluding pre-existing network-bound tests unrelated to this change)