### PR TITLE
metrics: add git_sync_server_error_total for non-user git failures

### DIFF
--- a/internal/gitsync/gitsync.go
+++ b/internal/gitsync/gitsync.go
@@ -142,6 +142,7 @@ func (s *Synchronizer) Execute(ctx context.Context) (map[string]any, error) {
 		if isGitUserError(err) {
 			return nil, syncerr.UserError{Cause: wrapped}
 		}
+		s.metrics.GitSyncServerError(s.sourceName, s.config.Repo)
 		return nil, wrapped
 	}
 	if done {

--- a/internal/gitsync/gitsync_test.go
+++ b/internal/gitsync/gitsync_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,6 +20,9 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	"github.com/open-policy-agent/opa-control-plane/internal/gitsync"
 	"github.com/open-policy-agent/opa-control-plane/internal/syncerr"
+	"github.com/open-policy-agent/opa-control-plane/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -164,6 +168,113 @@ func TestGitsyncUserError(t *testing.T) {
 			t.Fatalf("expected a plain error, got a syncerr.UserError: %v", err)
 		}
 	})
+}
+
+// TestGitsyncServerErrorMetric verifies that Execute records the git_sync_server_error_total
+// metric only for non-user (server/transient) failures, while git_sync_count_total{state="FAILED"}
+// counts every failure regardless of classification.
+func TestGitsyncServerErrorMetric(t *testing.T) {
+	const failed = "ocp_git_sync_count_total"
+	const serverError = "ocp_git_sync_server_error_total"
+
+	t.Run("user error does not record a server error", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		m := metrics.New(metrics.Options{Registerer: reg})
+
+		repo := t.TempDir() + "/does-not-exist"
+		ref := "refs/heads/master"
+		s := gitsync.New(t.TempDir()+"/dst", config.Git{
+			Repo:      repo,
+			Reference: &ref,
+		}, "test-source").WithMetrics(m)
+
+		if _, err := s.Execute(t.Context()); !syncerr.IsUserError(err) {
+			t.Fatalf("expected a syncerr.UserError, got: %v", err)
+		}
+
+		labels := map[string]string{"source": "test-source", "repo": repo}
+		if got := counterValue(t, reg, failed, mergeLabels(labels, "state", "FAILED")); got != 1 {
+			t.Errorf("FAILED count: want 1, got %v", got)
+		}
+		if got := counterValue(t, reg, serverError, labels); got != 0 {
+			t.Errorf("server error count: want 0, got %v", got)
+		}
+	})
+
+	t.Run("server error records both counters", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		m := metrics.New(metrics.Options{Registerer: reg})
+
+		repo := t.TempDir() + "/testing"
+		repository, err := git.PlainInit(repo, false)
+		if err != nil {
+			t.Fatalf("expected no error while initializing test repository: %v", err)
+		}
+		w, err := repository.Worktree()
+		if err != nil {
+			t.Fatalf("expected no error while getting worktree: %v", err)
+		}
+		if _, err := w.Commit("init", &git.CommitOptions{Author: &object.Signature{}, AllowEmptyCommits: true}); err != nil {
+			t.Fatalf("expected no error while committing changes: %v", err)
+		}
+
+		ref := "refs/heads/does-not-exist"
+		s := gitsync.New(t.TempDir()+"/dst", config.Git{
+			Repo:      repo,
+			Reference: &ref,
+		}, "test-source").WithMetrics(m)
+
+		if _, err := s.Execute(t.Context()); err == nil || syncerr.IsUserError(err) {
+			t.Fatalf("expected a non-user error, got: %v", err)
+		}
+
+		labels := map[string]string{"source": "test-source", "repo": repo}
+		if got := counterValue(t, reg, failed, mergeLabels(labels, "state", "FAILED")); got != 1 {
+			t.Errorf("FAILED count: want 1, got %v", got)
+		}
+		if got := counterValue(t, reg, serverError, labels); got != 1 {
+			t.Errorf("server error count: want 1, got %v", got)
+		}
+	})
+}
+
+func mergeLabels(labels map[string]string, key, value string) map[string]string {
+	out := make(map[string]string, len(labels)+1)
+	maps.Copy(out, labels)
+	out[key] = value
+	return out
+}
+
+func counterValue(t *testing.T, g prometheus.Gatherer, name string, labels map[string]string) float64 {
+	t.Helper()
+	mfs, err := g.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			if labelsMatch(metric.GetLabel(), labels) {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func labelsMatch(pairs []*dto.LabelPair, want map[string]string) bool {
+	got := make(map[string]string, len(pairs))
+	for _, p := range pairs {
+		got[p.GetName()] = p.GetValue()
+	}
+	for k, v := range want {
+		if got[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 // TestGitsyncCheckAccess verifies that CheckAccess succeeds against a reachable repository

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -15,6 +15,7 @@ type Metrics struct {
 	gatherer            prometheus.Gatherer
 	durationHistogram   *prometheus.HistogramVec
 	gitSyncCount        *prometheus.CounterVec
+	gitSyncServerError  *prometheus.CounterVec
 	gitSyncDuration     *prometheus.HistogramVec
 	bundleBuildCount    *prometheus.CounterVec
 	bundleBuildDuration *prometheus.HistogramVec

--- a/pkg/metrics/metrics_gitsync.go
+++ b/pkg/metrics/metrics_gitsync.go
@@ -23,6 +23,15 @@ func initGitSyncMetrics(m *Metrics, opts Options) {
 			},
 			[]string{"source", "repo", "state"},
 		)
+
+		m.gitSyncServerError = promauto.With(opts.Registerer).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: opts.Namespace,
+				Name:      "git_sync_server_error_total",
+				Help:      "Number of git syncs that failed due to a non-user (server/transient) error",
+			},
+			[]string{"source", "repo"},
+		)
 	}
 
 	if !isEnabled(opts.GitSyncDurationEnabled) {
@@ -45,6 +54,16 @@ func (m *Metrics) GitSyncFailed(source string, repo string) {
 		return
 	}
 	m.gitSyncCount.WithLabelValues(source, repo, "FAILED").Inc()
+}
+
+// GitSyncServerError records a git sync failure caused by a non-user
+// (server/transient) error, as opposed to a user misconfiguration. This is a
+// subset of the failures counted by GitSyncFailed.
+func (m *Metrics) GitSyncServerError(source string, repo string) {
+	if m == nil || m.gitSyncServerError == nil {
+		return
+	}
+	m.gitSyncServerError.WithLabelValues(source, repo).Inc()
 }
 
 func (m *Metrics) GitSyncSucceeded(source string, repo string, startTime time.Time) {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -15,6 +15,7 @@ func boolPtr(b bool) *bool { return &b }
 func TestNilMetricsSafe(t *testing.T) {
 	var m *Metrics
 	m.GitSyncFailed("src", "repo")
+	m.GitSyncServerError("src", "repo")
 	m.GitSyncSucceeded("src", "repo", time.Now())
 	m.BundleBuildFailed("b", "FAILED")
 	m.BundleBuildSucceeded("b", "SUCCESS", time.Now())
@@ -48,6 +49,7 @@ func TestDisable(t *testing.T) {
 			opts: Options{GitSyncEnabled: boolPtr(false)},
 			wantNil: []func(*Metrics) bool{
 				func(m *Metrics) bool { return m.gitSyncCount == nil },
+				func(m *Metrics) bool { return m.gitSyncServerError == nil },
 				func(m *Metrics) bool { return m.gitSyncDuration == nil },
 				func(m *Metrics) bool { return m.durationHistogram != nil }, // others unaffected
 			},
@@ -71,10 +73,14 @@ func TestGitSyncRecording(t *testing.T) {
 
 	m.GitSyncFailed("s1", "repo1")
 	m.GitSyncFailed("s1", "repo1")
+	m.GitSyncServerError("s1", "repo1")
 	m.GitSyncSucceeded("s1", "repo1", time.Now())
 
 	if got := testutil.ToFloat64(m.gitSyncCount.WithLabelValues("s1", "repo1", "FAILED")); got != 2 {
 		t.Errorf("FAILED count: want 2, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.gitSyncServerError.WithLabelValues("s1", "repo1")); got != 1 {
+		t.Errorf("server error count: want 1, got %v", got)
 	}
 	if got := testutil.ToFloat64(m.gitSyncCount.WithLabelValues("s1", "repo1", "SUCCESS")); got != 1 {
 		t.Errorf("SUCCESS count: want 1, got %v", got)


### PR DESCRIPTION
The git_sync_count_total{state="FAILED"} counter increments on every git
sync failure, regardless of cause. This conflates two very different
classes of error: user misconfiguration (a bad repo URL, invalid
credentials etc.) versus server-side or transient
failures (network issues, remote outages etc.).

This change adds a dedicated git_sync_server_error_total counter
that records only non-user failures. This can help operators to
alert on git_sync_server_error_total to catch real sync problems.