### PR TITLE
pkg/service: downgrade bundle status log when bundle deleted concurrently

### DIFF
--- a/pkg/service/worker.go
+++ b/pkg/service/worker.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"database/sql"
 	"errors"
 	"io/fs"
 	"time"
@@ -267,7 +268,13 @@ func (w *BundleWorker) report(ctx context.Context, state BuildState, phase Build
 	if w.database != nil {
 		if _, uerr := w.database.UpsertBundleStatus(ctx, w.tenant, w.bundleConfig.Name,
 			revision, phase.String(), state.String(), msg); uerr != nil {
-			w.log.Warnf("failed to track bundle status %q: %v", w.bundleConfig.Name, uerr)
+			if errors.Is(uerr, sql.ErrNoRows) {
+				// The bundle was deleted concurrently (e.g. by another process sharing
+				// the database) while this run was in flight; there's no status to track.
+				w.log.Debugf("failed to track bundle status %q: %v", w.bundleConfig.Name, uerr)
+			} else {
+				w.log.Warnf("failed to track bundle status %q: %v", w.bundleConfig.Name, uerr)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `UpsertBundleStatus` fails with `sql.ErrNoRows` when a bundle's config row is deleted (e.g. by another process sharing the database) while a worker run for that bundle is still in flight.
- This is an expected race, not an operational issue — the bundle is already gone, so there's nothing to track. Log it at debug level instead of warn to stop it from being noisy/alert-worthy while keeping other status-tracking failures at warn.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/service/... -run TestBundleWorkerExecute`
- [x] `gofmt -l pkg/service/worker.go` (no output)