### PR TITLE
service: thread database metrics through Init's database rebuild

### DIFF
--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/achille-roussel/sqlrange"
 	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/testcontainers/testcontainers-go"
 
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
@@ -16,6 +17,7 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/logging"
 	"github.com/open-policy-agent/opa-control-plane/internal/migrations"
 	"github.com/open-policy-agent/opa-control-plane/internal/test/dbs"
+	"github.com/open-policy-agent/opa-control-plane/pkg/metrics"
 )
 
 const tenant = "default"
@@ -1149,6 +1151,59 @@ func TestNewFromDB_NilDB(t *testing.T) {
 	_, err := database.NewFromDB(nil, "sqlite3")
 	if err == nil {
 		t.Fatal("expected error for nil db")
+	}
+}
+
+// TestMigratorWithMetrics guards against a regression where metrics attached
+// via Migrator.WithMetrics never reach the *database.Database that Run
+// returns: Run constructs its own database.New() internally and, without
+// this option, had no way to carry metrics through to it. sqlite is skipped
+// because the sqlite path intentionally bypasses connector instrumentation
+// (see instrumentConnector's callers).
+func TestMigratorWithMetrics(t *testing.T) {
+	ctx := t.Context()
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		if strings.HasPrefix(databaseType, "sqlite") {
+			continue
+		}
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				t.Cleanup(databaseConfig.Cleanup(t, ctr))
+			}
+
+			reg := prometheus.NewRegistry()
+			m := metrics.New(metrics.Options{Registerer: reg})
+
+			db, err := migrations.New().
+				WithConfig(databaseConfig.Database(t, ctr).Database).
+				WithLogger(logging.NewLogger(logging.Config{Level: logging.LevelDebug})).
+				WithMigrate(true).
+				WithMetrics(m).
+				Run(ctx)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			t.Cleanup(db.CloseDB)
+
+			if err := db.UpsertPrincipal(ctx, principal); err != nil {
+				t.Fatal(err)
+			}
+
+			mfs, err := reg.Gather()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, mf := range mfs {
+				if mf.GetName() == "ocp_database_query_count_total" {
+					return
+				}
+			}
+			t.Fatalf("expected ocp_database_query_count_total to be recorded against the registerer "+
+				"passed to Migrator.WithMetrics; got families: %v", mfs)
+		})
 	}
 }
 

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/database"
 	"github.com/open-policy-agent/opa-control-plane/internal/logging"
 	ext_authz "github.com/open-policy-agent/opa-control-plane/pkg/authz"
+	"github.com/open-policy-agent/opa-control-plane/pkg/metrics"
 )
 
 const (
@@ -53,6 +54,7 @@ type Migrator struct {
 	log        *logging.Logger
 	migrate    bool
 	authorizer ext_authz.Authorizer
+	metrics    *metrics.Metrics
 }
 
 func New() *Migrator {
@@ -61,6 +63,13 @@ func New() *Migrator {
 
 func (m *Migrator) WithConfig(db *config.Database) *Migrator {
 	m.config = db
+	return m
+}
+
+// WithMetrics enables per-query database metrics on the *database.Database
+// this Migrator returns from Run. Pass nil to disable (the default).
+func (m *Migrator) WithMetrics(metrics *metrics.Metrics) *Migrator {
+	m.metrics = metrics
 	return m
 }
 
@@ -85,6 +94,9 @@ func (m *Migrator) Run(ctx context.Context) (*database.Database, error) {
 	db := database.New().WithConfig(m.config).WithLogger(m.log)
 	if m.authorizer != nil {
 		db = db.WithAuthorizer(m.authorizer)
+	}
+	if m.metrics != nil {
+		db = db.WithMetrics(m.metrics)
 	}
 	if err := db.InitDB(ctx); err != nil {
 		return nil, fmt.Errorf("migrate: %w", err)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -334,6 +334,7 @@ func (s *Service) initDB(ctx context.Context) error {
 		WithLogger(s.log).
 		WithMigrate(s.migrateDB).
 		WithAuthorizer(s.authorizer).
+		WithMetrics(s.metrics).
 		Run(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- `Service.WithMetrics` attaches metrics to `s.database`, but `initDB()` unconditionally replaces `s.database` with the `*database.Database` returned by `migrations.New()...Run(ctx)`. Since `Migrator` had no way to receive metrics, the replacement database always came back unmetered, silently dropping whatever `WithMetrics` had configured before `Run()` was ever called.
- Adds `Migrator.WithMetrics`, mirroring the existing `WithAuthorizer` option, and threads it through: `db.WithMetrics` is applied before `InitDB` so the instrumented connector (postgres/mysql/cockroachdb) is wrapped from the start. `Service.initDB` now passes `s.metrics` into the same call chain that already passes `s.authorizer`.
- sqlite is intentionally unaffected: its `InitDB` path bypasses connector instrumentation entirely, so the new test skips it.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` clean
- [x] Added `TestMigratorWithMetrics` in `internal/database/database_test.go`, using the existing `dbs.Configs` testcontainer harness across postgres/mysql/cockroachdb, asserting `ocp_database_query_count_total` is recorded on the registerer passed to `Migrator.WithMetrics`. Could not run this locally (no Docker access in this environment) — relying on CI.
- [x] CI (testcontainers) to confirm