### PR TITLE
fix(builder): keep VCS metadata out of the bundle revision hash

### DIFF
--- a/internal/gitsync/gitsync.go
+++ b/internal/gitsync/gitsync.go
@@ -41,6 +41,15 @@ import (
 // bundle builder.
 const configFile = "ocpconfig"
 
+// MetadataFiles are glob patterns matching git's own bookkeeping inside a
+// checkout.
+var MetadataFiles = []string{
+	".git",       // metadata directory, or a gitfile pointing at one
+	".git/**",    // its contents
+	"**/.git",    // nested metadata, at any depth
+	"**/.git/**", // and its contents
+}
+
 func init() {
 	// For Azure DevOps compatibility. More details: https://github.com/go-git/go-git/issues/64
 	transport.UnsupportedCapabilities = []capability.Capability{

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -77,23 +77,13 @@ func (s *Source) Wipe() error {
 	return nil
 }
 
-var vcsExcludes = []string{
-	".git",       // checkout metadata directory
-	".git/**",    // its contents
-	"**/.git",    // submodule metadata, at any depth
-	"**/.git/**", // and its contents
-}
-
 func (s *Source) AddDir(d Dir) error {
 	// We record the Dir struct because we need to know whether we can Wipe().
 	// `os.DirFS()` does not read anything until it's used, so it's OK to alter
 	// the underlying OS filesystem via Wipe() or when applying the `Transforms`.
 	s.dirs = append(s.dirs, d)
 
-	excluded := d.ExcludedFiles
-	if d.ExcludeVCS {
-		excluded = slices.Concat(excluded, vcsExcludes)
-	}
+	excluded := slices.Concat(d.ExcludedFiles, d.ExcludedMetadataFiles)
 
 	f, err := ocp_fs.NewFilterFS(os.DirFS(d.Path), d.IncludedFiles, excluded)
 	if err != nil {
@@ -170,11 +160,11 @@ func (s *Source) Transform(ctx context.Context) (*bytes.Buffer, error) {
 }
 
 type Dir struct {
-	Path          string   // local fs path to source files
-	Wipe          bool     // bit indicates if worker should delete directory before synchronization
-	IncludedFiles []string // inclusion filter on files to load from path
-	ExcludedFiles []string // exclusion filter on files to skip from path
-	ExcludeVCS    bool     // drop version control metadata
+	Path                  string   // local fs path to source files
+	Wipe                  bool     // bit indicates if worker should delete directory before synchronization
+	IncludedFiles         []string // inclusion filter on files to load from path
+	ExcludedFiles         []string // exclusion filter on files to skip from path
+	ExcludedMetadataFiles []string // excludes files that exist in the directory but are not part of its source content (eg. git checkout's .git)
 }
 
 type Builder struct {

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -77,13 +77,25 @@ func (s *Source) Wipe() error {
 	return nil
 }
 
+var vcsExcludes = []string{
+	".git",       // checkout metadata directory
+	".git/**",    // its contents
+	"**/.git",    // submodule metadata, at any depth
+	"**/.git/**", // and its contents
+}
+
 func (s *Source) AddDir(d Dir) error {
 	// We record the Dir struct because we need to know whether we can Wipe().
 	// `os.DirFS()` does not read anything until it's used, so it's OK to alter
 	// the underlying OS filesystem via Wipe() or when applying the `Transforms`.
 	s.dirs = append(s.dirs, d)
 
-	f, err := ocp_fs.NewFilterFS(os.DirFS(d.Path), d.IncludedFiles, d.ExcludedFiles)
+	excluded := d.ExcludedFiles
+	if d.ExcludeVCS {
+		excluded = slices.Concat(excluded, vcsExcludes)
+	}
+
+	f, err := ocp_fs.NewFilterFS(os.DirFS(d.Path), d.IncludedFiles, excluded)
 	if err != nil {
 		return err
 	}
@@ -162,6 +174,7 @@ type Dir struct {
 	Wipe          bool     // bit indicates if worker should delete directory before synchronization
 	IncludedFiles []string // inclusion filter on files to load from path
 	ExcludedFiles []string // exclusion filter on files to skip from path
+	ExcludeVCS    bool     // drop version control metadata
 }
 
 type Builder struct {

--- a/pkg/builder/revision_test.go
+++ b/pkg/builder/revision_test.go
@@ -1,0 +1,203 @@
+package builder_test
+
+import (
+	"bytes"
+	"context"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-policy-agent/opa-control-plane/internal/config"
+	ocp_fs "github.com/open-policy-agent/opa-control-plane/internal/fs"
+	"github.com/open-policy-agent/opa-control-plane/internal/gitsync"
+	"github.com/open-policy-agent/opa-control-plane/pkg/builder"
+)
+
+func TestRevisionStableAcrossClones(t *testing.T) {
+	upstream := newUpstreamRepo(t, map[string]string{
+		"policy.rego": "package p\n\nallow := true\n",
+		"data.json":   `{"team":"authz"}`,
+	})
+
+	// Two independent clones of the very same commit.
+	a := cloneRepo(t, upstream, "clone-a")
+	b := cloneRepo(t, upstream, "clone-b")
+
+	if got, want := hashOf(t, filepath.Join(a, "policy.rego")), hashOf(t, filepath.Join(b, "policy.rego")); got != want {
+		t.Fatalf("precondition failed: clones differ in tracked content")
+	}
+
+	revA := buildRevision(t, a, true)
+	revB := buildRevision(t, b, true)
+
+	if revA != revB {
+		t.Errorf("revision differs across clones of identical content:\n clone-a = %s\n clone-b = %s", revA, revB)
+	}
+
+	// Without the exclusion the two clones must disagree
+	rawA := buildRevision(t, a, false)
+	rawB := buildRevision(t, b, false)
+
+	if rawA == rawB {
+		t.Errorf("unexpected same revision across clones %s", rawA)
+	}
+	if rawA == revA {
+		t.Errorf("excluding VCS metadata did not change the hash (%s); the exclusion is not taking effect", revA)
+	}
+}
+
+func TestVCSExclusionKeepsSourceContent(t *testing.T) {
+	upstream := newUpstreamRepo(t, map[string]string{
+		"policy.rego":               "package p\n\nallow := true\n",
+		"data.json":                 `{"a":1}`,
+		".gitignore":                "*.tmp\n",
+		".github/workflows/ci.yaml": "name: ci\n",
+		"lib/.gitkeep":              "",
+	})
+	clone := cloneRepo(t, upstream, "clone")
+
+	got := hashedFiles(t, clone, true)
+
+	want := map[string]bool{
+		".github/workflows/ci.yaml": true,
+		".gitignore":                true,
+		"data.json":                 true,
+		"lib/.gitkeep":              true,
+		"policy.rego":               true,
+	}
+
+	for _, f := range got {
+		if !want[f] {
+			t.Errorf("unexpected file in hashed filesystem: %s", f)
+		}
+		delete(want, f)
+	}
+	for f := range want {
+		t.Errorf("tracked file wrongly excluded from hashed filesystem: %s", f)
+	}
+}
+
+func newUpstreamRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	dir := filepath.Join(t.TempDir(), "upstream")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		// Keep the committer deterministic and independent of the developer's config.
+		cmd.Env = append(os.Environ(),
+			"GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_SYSTEM=/dev/null",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	git("init", "-b", "main")
+	git("config", "user.email", "test@example.com")
+	git("config", "user.name", "test")
+
+	for name, content := range files {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	git("add", "-A")
+	git("commit", "-m", "initial")
+
+	return dir
+}
+
+func cloneRepo(t *testing.T, upstream, name string) string {
+	t.Helper()
+
+	dir := filepath.Join(t.TempDir(), name)
+	ref := "main"
+	if _, err := gitsync.New(dir, config.Git{Repo: upstream, Reference: &ref}, "test_src").Execute(context.Background()); err != nil {
+		t.Fatalf("clone %s: %v", name, err)
+	}
+	return dir
+}
+
+func buildRevision(t *testing.T, dir string, excludeVCS bool) string {
+	t.Helper()
+
+	src := builder.NewSource("test_src")
+	if err := src.AddDir(builder.Dir{Path: filepath.ToSlash(dir), ExcludeVCS: excludeVCS}); err != nil {
+		t.Fatal(err)
+	}
+
+	var revision string
+	err := builder.New().
+		WithSources([]*builder.Source{src}).
+		WithOutput(bytes.NewBuffer(nil)).
+		WithRevisionFunc(func(fsys fs.FS) (string, error) {
+			var err error
+			revision, err = ocp_fs.HashFS(fsys)
+			return revision, err
+		}).
+		Build(t.Context())
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if revision == "" {
+		t.Fatal("revision func was never invoked")
+	}
+	return revision
+}
+
+func hashedFiles(t *testing.T, dir string, excludeVCS bool) []string {
+	t.Helper()
+
+	src := builder.NewSource("test_src")
+	if err := src.AddDir(builder.Dir{Path: filepath.ToSlash(dir), ExcludeVCS: excludeVCS}); err != nil {
+		t.Fatal(err)
+	}
+
+	var files []string
+	err := builder.New().
+		WithSources([]*builder.Source{src}).
+		WithOutput(bytes.NewBuffer(nil)).
+		WithRevisionFunc(func(fsys fs.FS) (string, error) {
+			return "x", fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+				if err != nil || d.IsDir() {
+					return err
+				}
+				// Strip the "test_src/" mount prefix the builder applies.
+				rel := p
+				if i := len("test_src/"); len(p) > i && p[:i] == "test_src/" {
+					rel = p[i:]
+				}
+				files = append(files, rel)
+				return nil
+			})
+		}).
+		Build(t.Context())
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	return files
+}
+
+func hashOf(t *testing.T, path string) string {
+	t.Helper()
+
+	bs, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(bs)
+}

--- a/pkg/builder/revision_test.go
+++ b/pkg/builder/revision_test.go
@@ -132,11 +132,21 @@ func cloneRepo(t *testing.T, upstream, name string) string {
 	return dir
 }
 
+func metadataFiles(excludeVCS bool) []string {
+	if excludeVCS {
+		return gitsync.MetadataFiles
+	}
+	return nil
+}
+
 func buildRevision(t *testing.T, dir string, excludeVCS bool) string {
 	t.Helper()
 
 	src := builder.NewSource("test_src")
-	if err := src.AddDir(builder.Dir{Path: filepath.ToSlash(dir), ExcludeVCS: excludeVCS}); err != nil {
+	if err := src.AddDir(builder.Dir{
+		Path:                  filepath.ToSlash(dir),
+		ExcludedMetadataFiles: metadataFiles(excludeVCS),
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -163,7 +173,10 @@ func hashedFiles(t *testing.T, dir string, excludeVCS bool) []string {
 	t.Helper()
 
 	src := builder.NewSource("test_src")
-	if err := src.AddDir(builder.Dir{Path: filepath.ToSlash(dir), ExcludeVCS: excludeVCS}); err != nil {
+	if err := src.AddDir(builder.Dir{
+		Path:                  filepath.ToSlash(dir),
+		ExcludedMetadataFiles: metadataFiles(excludeVCS),
+	}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -589,13 +589,13 @@ func newSource(name string) *source {
 	}
 }
 
-func (src *source) addDir(dir string, wipe bool, includedFiles []string, excludedFiles []string, excludeVCS bool) {
+func (src *source) addDir(dir string, wipe bool, includedFiles, excludedFiles, metadataFiles []string) {
 	_ = src.Source.AddDir(builder.Dir{
-		Path:          filepath.ToSlash(dir),
-		Wipe:          wipe,
-		IncludedFiles: includedFiles,
-		ExcludedFiles: excludedFiles,
-		ExcludeVCS:    excludeVCS,
+		Path:                  filepath.ToSlash(dir),
+		Wipe:                  wipe,
+		IncludedFiles:         includedFiles,
+		ExcludedFiles:         excludedFiles,
+		ExcludedMetadataFiles: metadataFiles,
 	})
 }
 
@@ -609,7 +609,7 @@ func (src *source) SyncGit(syncs *[]sourceSynchronizer, sourceName string, git c
 		if git.Path != nil {
 			srcDir = join(srcDir, *git.Path)
 		}
-		src.addDir(srcDir, false, git.IncludedFiles, git.ExcludedFiles, true)
+		src.addDir(srcDir, false, git.IncludedFiles, git.ExcludedFiles, gitsync.MetadataFiles)
 		if reqCommit != "" {
 			git.Commit = &reqCommit
 		}
@@ -684,7 +684,7 @@ func (src *source) SyncDatasources(syncs *[]sourceSynchronizer, sourceName strin
 		}
 	}
 	if len(datasources) > 0 {
-		src.addDir(dir, true, nil, nil, false)
+		src.addDir(dir, true, nil, nil, nil)
 	}
 	return src
 }
@@ -699,7 +699,7 @@ func (src *source) SyncSourceSQL(syncs *[]sourceSynchronizer, sourceID int64, na
 		sourceName: name,
 		sourceType: "sql",
 	})
-	src.addDir(dir, true, nil, nil, false)
+	src.addDir(dir, true, nil, nil, nil)
 	return src
 }
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -589,12 +589,13 @@ func newSource(name string) *source {
 	}
 }
 
-func (src *source) addDir(dir string, wipe bool, includedFiles []string, excludedFiles []string) {
+func (src *source) addDir(dir string, wipe bool, includedFiles []string, excludedFiles []string, excludeVCS bool) {
 	_ = src.Source.AddDir(builder.Dir{
 		Path:          filepath.ToSlash(dir),
 		Wipe:          wipe,
 		IncludedFiles: includedFiles,
 		ExcludedFiles: excludedFiles,
+		ExcludeVCS:    excludeVCS,
 	})
 }
 
@@ -608,7 +609,7 @@ func (src *source) SyncGit(syncs *[]sourceSynchronizer, sourceName string, git c
 		if git.Path != nil {
 			srcDir = join(srcDir, *git.Path)
 		}
-		src.addDir(srcDir, false, git.IncludedFiles, git.ExcludedFiles)
+		src.addDir(srcDir, false, git.IncludedFiles, git.ExcludedFiles, true)
 		if reqCommit != "" {
 			git.Commit = &reqCommit
 		}
@@ -683,7 +684,7 @@ func (src *source) SyncDatasources(syncs *[]sourceSynchronizer, sourceName strin
 		}
 	}
 	if len(datasources) > 0 {
-		src.addDir(dir, true, nil, nil)
+		src.addDir(dir, true, nil, nil, false)
 	}
 	return src
 }
@@ -698,7 +699,7 @@ func (src *source) SyncSourceSQL(syncs *[]sourceSynchronizer, sourceID int64, na
 		sourceName: name,
 		sourceType: "sql",
 	})
-	src.addDir(dir, true, nil, nil)
+	src.addDir(dir, true, nil, nil, false)
 	return src
 }
 


### PR DESCRIPTION
Bundle revisions resolved from `input.bundle.hash` changed for identical content. A new version on every re-clone was created as the hash was computed over the whole checkout, `.git`(specifically index) included.