### PR TITLE
service: skip build when resolved revision already matches stored bundle

### DIFF
--- a/internal/s3/s3.go
+++ b/internal/s3/s3.go
@@ -26,10 +26,12 @@ import (
 )
 
 var (
-	_ ext_os.ObjectStorage = (*AmazonS3)(nil)
-	_ ext_os.ObjectStorage = (*GCPCloudStorage)(nil)
-	_ ext_os.ObjectStorage = (*AzureBlobStorage)(nil)
-	_ ext_os.ObjectStorage = (*FileSystemStorage)(nil)
+	_ ext_os.ObjectStorage          = (*AmazonS3)(nil)
+	_ ext_os.ObjectStorage          = (*GCPCloudStorage)(nil)
+	_ ext_os.ObjectStorage          = (*AzureBlobStorage)(nil)
+	_ ext_os.ObjectStorage          = (*FileSystemStorage)(nil)
+	_ ext_os.VersionedObjectStorage = (*AmazonS3)(nil)
+	_ ext_os.VersionedObjectStorage = (*GCPCloudStorage)(nil)
 )
 
 type (
@@ -279,6 +281,24 @@ func (s *AmazonS3) check(ctx context.Context, body io.Reader) ([]byte, bool, err
 	return digest, output.Metadata["sha256"] == hex.EncodeToString(digest), nil
 }
 
+// LatestRevision returns the revision recorded on the currently stored
+// object's metadata, without downloading or hashing its content.
+func (s *AmazonS3) LatestRevision(ctx context.Context, _ ext_os.UploadOptions) (string, error) {
+	output, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(s.key),
+	})
+	if err != nil {
+		var noKey *types.NoSuchKey
+		var notFound *types.NotFound
+		if errors.As(err, &noKey) || errors.As(err, &notFound) {
+			return "", nil
+		}
+		return "", err
+	}
+	return output.Metadata["revision"], nil
+}
+
 func (s *GCPCloudStorage) Upload(ctx context.Context, body io.ReadSeeker, opts ext_os.UploadOptions) error {
 	digest, equal, err := s.check(ctx, body)
 	if err != nil {
@@ -329,6 +349,19 @@ func (s *GCPCloudStorage) check(ctx context.Context, body io.Reader) ([]byte, bo
 	}
 
 	return digest, attrs.Metadata["sha256"] == hex.EncodeToString(digest), nil
+}
+
+// LatestRevision returns the revision recorded on the currently stored
+// object's metadata, without downloading or hashing its content.
+func (s *GCPCloudStorage) LatestRevision(ctx context.Context, _ ext_os.UploadOptions) (string, error) {
+	attrs, err := s.client.Bucket(s.bucket).Object(s.object).Attrs(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	return attrs.Metadata["revision"], nil
 }
 
 func (s *AzureBlobStorage) Upload(ctx context.Context, body io.ReadSeeker, opts ext_os.UploadOptions) error {

--- a/internal/s3/s3_test.go
+++ b/internal/s3/s3_test.go
@@ -7,11 +7,15 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/johannesboyne/gofakes3"
@@ -20,6 +24,23 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
 	ext_os "github.com/open-policy-agent/opa-control-plane/pkg/objectstorage"
 )
+
+// inProcessHTTPClient dispatches requests directly to an in-memory
+// http.Handler instead of a real network connection, so tests using it don't
+// need to bind a TCP listener.
+type inProcessHTTPClient struct{ handler http.Handler }
+
+func (c inProcessHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	// httptest.NewRecorder doesn't serialize req.ContentLength onto the wire
+	// the way a real transport would, so gofakes3's MissingContentLength
+	// check needs it set explicitly here.
+	if req.ContentLength > 0 {
+		req.Header.Set("Content-Length", strconv.FormatInt(req.ContentLength, 10))
+	}
+	rec := httptest.NewRecorder()
+	c.handler.ServeHTTP(rec, req)
+	return rec.Result(), nil
+}
 
 func TestS3(t *testing.T) {
 	// Set mock AWS credentials to avoid IMDS errors.
@@ -265,6 +286,62 @@ func TestS3NotModified(t *testing.T) {
 	}
 }
 
+func TestS3LatestRevision(t *testing.T) {
+	// Dispatches directly to gofakes3's handler in-process, so this test
+	// doesn't need to bind a real TCP listener.
+	mock := s3mem.New()
+	if err := mock.CreateBucket("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	client := s3.NewFromConfig(aws.Config{
+		Region:      "us-east-1",
+		Credentials: credentials.NewStaticCredentialsProvider("mock-access-key", "mock-secret-key", ""),
+		HTTPClient:  inProcessHTTPClient{handler: gofakes3.New(mock).Server()},
+	}, func(o *s3.Options) {
+		o.UsePathStyle = true
+		o.BaseEndpoint = aws.String("http://s3.local")
+	})
+
+	s3Storage := &AmazonS3{bucket: "test", key: "latest-revision", client: client}
+	var storage ext_os.ObjectStorage = s3Storage
+
+	// No object uploaded yet: LatestRevision should report "" rather than error.
+	rev, err := s3Storage.LatestRevision(ctx, ext_os.UploadOptions{})
+	if err != nil {
+		t.Fatalf("expected no error for missing object, got %v", err)
+	}
+	if rev != "" {
+		t.Fatalf("expected empty revision for missing object, got %q", rev)
+	}
+
+	// Upload without a revision: LatestRevision should still report "".
+	if err := storage.Upload(ctx, bytes.NewReader([]byte("v1")), ext_os.UploadOptions{}); err != nil {
+		t.Fatalf("upload without revision: %v", err)
+	}
+	rev, err = s3Storage.LatestRevision(ctx, ext_os.UploadOptions{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if rev != "" {
+		t.Fatalf("expected empty revision when none was recorded, got %q", rev)
+	}
+
+	// Upload with a revision: LatestRevision should report it back.
+	if err := storage.Upload(ctx, bytes.NewReader([]byte("v2")), ext_os.UploadOptions{Revision: "rev-abc"}); err != nil {
+		t.Fatalf("upload with revision: %v", err)
+	}
+	rev, err = s3Storage.LatestRevision(ctx, ext_os.UploadOptions{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if rev != "rev-abc" {
+		t.Fatalf("expected revision %q, got %q", "rev-abc", rev)
+	}
+}
+
 func TestFileSystemNotModified(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bundle.tar.gz")
@@ -336,5 +413,60 @@ func TestGCSNotModified(t *testing.T) {
 	r2 := bytes.NewReader([]byte("different content"))
 	if err := gcsStorage.Upload(t.Context(), r2, ext_os.UploadOptions{}); err != nil {
 		t.Fatalf("third upload: %v", err)
+	}
+}
+
+func TestGCSLatestRevision(t *testing.T) {
+	// NoListener avoids binding a real TCP port, since this test doesn't
+	// otherwise depend on the network transport fake-gcs-server normally uses.
+	mock, err := fakestorage.NewServerWithOptions(fakestorage.Options{NoListener: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Stop()
+
+	mock.CreateBucketWithOpts(fakestorage.CreateBucketOpts{
+		Name: "test",
+	})
+
+	gcsStorage := &GCPCloudStorage{
+		bucket: "test",
+		object: "latest-revision",
+		client: mock.Client(),
+	}
+
+	ctx := t.Context()
+
+	// No object uploaded yet: LatestRevision should report "" rather than error.
+	rev, err := gcsStorage.LatestRevision(ctx, ext_os.UploadOptions{})
+	if err != nil {
+		t.Fatalf("expected no error for missing object, got %v", err)
+	}
+	if rev != "" {
+		t.Fatalf("expected empty revision for missing object, got %q", rev)
+	}
+
+	// Upload without a revision: LatestRevision should still report "".
+	if err := gcsStorage.Upload(ctx, bytes.NewReader([]byte("v1")), ext_os.UploadOptions{}); err != nil {
+		t.Fatalf("upload without revision: %v", err)
+	}
+	rev, err = gcsStorage.LatestRevision(ctx, ext_os.UploadOptions{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if rev != "" {
+		t.Fatalf("expected empty revision when none was recorded, got %q", rev)
+	}
+
+	// Upload with a revision: LatestRevision should report it back.
+	if err := gcsStorage.Upload(ctx, bytes.NewReader([]byte("v2")), ext_os.UploadOptions{Revision: "rev-xyz"}); err != nil {
+		t.Fatalf("upload with revision: %v", err)
+	}
+	rev, err = gcsStorage.LatestRevision(ctx, ext_os.UploadOptions{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if rev != "rev-xyz" {
+		t.Fatalf("expected revision %q, got %q", "rev-xyz", rev)
 	}
 }

--- a/pkg/objectstorage/objectstorage.go
+++ b/pkg/objectstorage/objectstorage.go
@@ -29,3 +29,15 @@ type ObjectStorage interface {
 	// Download retrieves a bundle artifact from object storage.
 	Download(ctx context.Context) (io.Reader, error)
 }
+
+// VersionedObjectStorage is an optional capability an ObjectStorage
+// implementation may provide. Callers can check for it via a type assertion;
+// implementations that can't answer this cheaply (without building the
+// bundle first) should simply not implement it.
+type VersionedObjectStorage interface {
+	// LatestRevision returns the revision recorded for the most recently
+	// stored bundle matching opts.Tenant/opts.Name, without requiring the
+	// caller to build the bundle first. It returns "" if no such bundle
+	// exists yet, or the backend can't determine its revision cheaply.
+	LatestRevision(ctx context.Context, opts UploadOptions) (string, error)
+}

--- a/pkg/service/worker.go
+++ b/pkg/service/worker.go
@@ -184,6 +184,36 @@ func (w *BundleWorker) Execute(ctx context.Context) time.Time {
 		}
 	}
 
+	_, needsBundleHash, err := extractRevisionRefs(w.bundleConfig.Revision)
+	if err != nil {
+		w.log.Warnf("failed to parse revision expression for bundle %q: %v", w.bundleConfig.Name, err)
+		return w.report(ctx, BuildStateConfigError, BuildPhaseSync, database.SentinelRevision, startTime, err)
+	}
+
+	// If the revision doesn't depend on the built bundle's own content hash,
+	// it can be resolved from sync metadata alone, before transform/build run.
+	// In that case, ask the storage backend (if it supports answering this
+	// cheaply) whether a bundle with this revision is already the latest one
+	// stored; if so, skip the rest of this iteration entirely.
+	if !needsBundleHash && w.storage != nil {
+		if vs, ok := w.storage.(ext_os.VersionedObjectStorage); ok {
+			earlyRevision, err := resolveRevision(ctx, w.bundleConfig.Revision, sourceMetadata, "")
+			if err != nil {
+				w.log.Warnf("failed to resolve revision for bundle %q: %v", w.bundleConfig.Name, err)
+				return w.report(ctx, BuildStateConfigError, BuildPhaseSync, database.SentinelRevision, startTime, err)
+			}
+			if earlyRevision != "" {
+				latest, err := vs.LatestRevision(ctx, ext_os.UploadOptions{Tenant: w.tenant, Name: w.bundleConfig.Name})
+				if err != nil {
+					w.log.Warnf("failed to look up latest revision for bundle %q: %v", w.bundleConfig.Name, err)
+				} else if latest != "" && latest == earlyRevision {
+					w.log.Debugf("Bundle %q revision %q already up to date, skipping build.", w.bundleConfig.Name, earlyRevision)
+					return w.report(ctx, BuildStateSuccess, BuildPhasePush, earlyRevision, startTime, nil)
+				}
+			}
+		}
+	}
+
 	for _, src := range w.sources {
 		buf, err := src.Transform(ctx)
 		if buf != nil && buf.Len() > 0 {
@@ -196,8 +226,6 @@ func (w *BundleWorker) Execute(ctx context.Context) time.Time {
 	}
 
 	buffer := bytes.NewBuffer(nil)
-
-	_, needsBundleHash, _ := extractRevisionRefs(w.bundleConfig.Revision)
 
 	var resolvedRevision string
 	b := builder.New().

--- a/pkg/service/worker_test.go
+++ b/pkg/service/worker_test.go
@@ -3,6 +3,9 @@ package service
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/open-policy-agent/opa-control-plane/internal/config"
@@ -12,7 +15,25 @@ import (
 	"github.com/open-policy-agent/opa-control-plane/internal/progress"
 	"github.com/open-policy-agent/opa-control-plane/internal/syncerr"
 	"github.com/open-policy-agent/opa-control-plane/internal/test/dbs"
+	"github.com/open-policy-agent/opa-control-plane/pkg/builder"
+	ext_os "github.com/open-policy-agent/opa-control-plane/pkg/objectstorage"
 )
+
+// newTestSource builds a minimal builder.Source backed by a temp directory
+// containing a single data file, sufficient for BundleWorker.Execute to run
+// a real build.
+func newTestSource(t *testing.T) *builder.Source {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "data.json"), []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := builder.NewSource("test-source")
+	if err := src.AddDir(builder.Dir{Path: dir}); err != nil {
+		t.Fatal(err)
+	}
+	return src
+}
 
 type fakeSynchronizer struct {
 	err error
@@ -215,4 +236,185 @@ func TestBundleWorkerExecute_SyncFailurePersisted(t *testing.T) {
 	if status.Revision != database.SentinelRevision {
 		t.Fatalf("expected sentinel revision %q, got %q", database.SentinelRevision, status.Revision)
 	}
+}
+
+// fakeStorage is a plain ext_os.ObjectStorage that records how many times
+// Upload was called, without implementing VersionedObjectStorage.
+type fakeStorage struct {
+	uploads int
+}
+
+func (f *fakeStorage) Upload(context.Context, io.ReadSeeker, ext_os.UploadOptions) error {
+	f.uploads++
+	return nil
+}
+
+func (*fakeStorage) Download(context.Context) (io.Reader, error) {
+	return nil, errors.New("not implemented")
+}
+
+// fakeVersionedStorage additionally implements VersionedObjectStorage, so
+// BundleWorker.Execute can attempt the early-skip path against it.
+type fakeVersionedStorage struct {
+	fakeStorage
+	latestRevision string
+	latestErr      error
+	latestCalls    int
+}
+
+func (f *fakeVersionedStorage) LatestRevision(context.Context, ext_os.UploadOptions) (string, error) {
+	f.latestCalls++
+	return f.latestRevision, f.latestErr
+}
+
+// TestBundleWorkerExecute_EarlySkip verifies the early-skip path added to
+// Execute: when the bundle's revision expression doesn't depend on the
+// built bundle's content hash, and the storage backend reports that
+// revision as already the latest stored one, Execute should short-circuit
+// before ever calling Upload.
+func TestBundleWorkerExecute_EarlySkip(t *testing.T) {
+	t.Run("skips build and upload when resolved revision already matches", func(t *testing.T) {
+		storage := &fakeVersionedStorage{latestRevision: "rev-1"}
+
+		worker := NewBundleWorker(t.TempDir(), &config.Bundle{
+			Name:     "test_bundle",
+			Revision: `"rev-1"`,
+		}, nil, nil, logging.NewLogger(logging.Config{}), progress.New(true, 1, "test")).
+			WithSingleShot(true).
+			WithStorage(storage)
+
+		worker.Execute(t.Context())
+
+		if storage.latestCalls != 1 {
+			t.Fatalf("expected LatestRevision to be called once, got %d", storage.latestCalls)
+		}
+		if storage.uploads != 0 {
+			t.Fatalf("expected Upload to be skipped, got %d calls", storage.uploads)
+		}
+		if worker.status.State != BuildStateSuccess {
+			t.Fatalf("expected state %v, got %v", BuildStateSuccess, worker.status.State)
+		}
+	})
+
+	t.Run("builds and uploads when resolved revision differs from latest stored", func(t *testing.T) {
+		storage := &fakeVersionedStorage{latestRevision: "rev-old"}
+
+		worker := NewBundleWorker(t.TempDir(), &config.Bundle{
+			Name:     "test_bundle",
+			Revision: `"rev-new"`,
+		}, nil, nil, logging.NewLogger(logging.Config{}), progress.New(true, 1, "test")).
+			WithSingleShot(true).
+			WithSources([]*builder.Source{newTestSource(t)}).
+			WithStorage(storage)
+
+		worker.Execute(t.Context())
+
+		if storage.latestCalls != 1 {
+			t.Fatalf("expected LatestRevision to be called once, got %d", storage.latestCalls)
+		}
+		if storage.uploads != 1 {
+			t.Fatalf("expected Upload to be called once, got %d", storage.uploads)
+		}
+		if worker.status.State != BuildStateSuccess {
+			t.Fatalf("expected state %v, got %v", BuildStateSuccess, worker.status.State)
+		}
+	})
+
+	t.Run("builds and uploads when no stored revision exists yet", func(t *testing.T) {
+		storage := &fakeVersionedStorage{latestRevision: ""}
+
+		worker := NewBundleWorker(t.TempDir(), &config.Bundle{
+			Name:     "test_bundle",
+			Revision: `"rev-new"`,
+		}, nil, nil, logging.NewLogger(logging.Config{}), progress.New(true, 1, "test")).
+			WithSingleShot(true).
+			WithSources([]*builder.Source{newTestSource(t)}).
+			WithStorage(storage)
+
+		worker.Execute(t.Context())
+
+		if storage.uploads != 1 {
+			t.Fatalf("expected Upload to be called once, got %d", storage.uploads)
+		}
+	})
+
+	t.Run("proceeds through normal build when LatestRevision errors", func(t *testing.T) {
+		storage := &fakeVersionedStorage{latestErr: errors.New("head object failed")}
+
+		worker := NewBundleWorker(t.TempDir(), &config.Bundle{
+			Name:     "test_bundle",
+			Revision: `"rev-new"`,
+		}, nil, nil, logging.NewLogger(logging.Config{}), progress.New(true, 1, "test")).
+			WithSingleShot(true).
+			WithSources([]*builder.Source{newTestSource(t)}).
+			WithStorage(storage)
+
+		worker.Execute(t.Context())
+
+		if storage.uploads != 1 {
+			t.Fatalf("expected Upload to be called once despite LatestRevision error, got %d", storage.uploads)
+		}
+		if worker.status.State != BuildStateSuccess {
+			t.Fatalf("expected state %v, got %v", BuildStateSuccess, worker.status.State)
+		}
+	})
+
+	t.Run("does not attempt early skip when storage doesn't implement VersionedObjectStorage", func(t *testing.T) {
+		storage := &fakeStorage{}
+
+		worker := NewBundleWorker(t.TempDir(), &config.Bundle{
+			Name:     "test_bundle",
+			Revision: `"rev-new"`,
+		}, nil, nil, logging.NewLogger(logging.Config{}), progress.New(true, 1, "test")).
+			WithSingleShot(true).
+			WithSources([]*builder.Source{newTestSource(t)}).
+			WithStorage(storage)
+
+		worker.Execute(t.Context())
+
+		if storage.uploads != 1 {
+			t.Fatalf("expected Upload to be called once, got %d", storage.uploads)
+		}
+	})
+
+	t.Run("does not attempt early skip when revision depends on bundle content hash", func(t *testing.T) {
+		storage := &fakeVersionedStorage{latestRevision: "should-be-ignored"}
+
+		worker := NewBundleWorker(t.TempDir(), &config.Bundle{
+			Name:     "test_bundle",
+			Revision: `input.bundle.hash`,
+		}, nil, nil, logging.NewLogger(logging.Config{}), progress.New(true, 1, "test")).
+			WithSingleShot(true).
+			WithSources([]*builder.Source{newTestSource(t)}).
+			WithStorage(storage)
+
+		worker.Execute(t.Context())
+
+		if storage.latestCalls != 0 {
+			t.Fatalf("expected LatestRevision not to be called, got %d calls", storage.latestCalls)
+		}
+		if storage.uploads != 1 {
+			t.Fatalf("expected Upload to be called once, got %d", storage.uploads)
+		}
+	})
+
+	t.Run("reports config error when revision expression is invalid", func(t *testing.T) {
+		storage := &fakeVersionedStorage{}
+
+		worker := NewBundleWorker(t.TempDir(), &config.Bundle{
+			Name:     "test_bundle",
+			Revision: "not a valid {{{ rego",
+		}, nil, nil, logging.NewLogger(logging.Config{}), progress.New(true, 1, "test")).
+			WithSingleShot(true).
+			WithStorage(storage)
+
+		worker.Execute(t.Context())
+
+		if worker.status.State != BuildStateConfigError {
+			t.Fatalf("expected state %v, got %v", BuildStateConfigError, worker.status.State)
+		}
+		if storage.uploads != 0 || storage.latestCalls != 0 {
+			t.Fatalf("expected no storage interaction, got uploads=%d latestCalls=%d", storage.uploads, storage.latestCalls)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Today, `Upload()` implementations can already skip re-uploading identical bundle content via `ErrNotModified`, but that check only runs after the full sync/transform/build pipeline has already produced the bundle bytes to hash. For bundles whose revision doesn't depend on the built bundle's own content hash (i.e. doesn't reference `input.bundle.hash`), the revision is fully resolvable right after sync, before transform/build ever run.

This PR adds an optional `VersionedObjectStorage` interface with a single `LatestRevision` method. `BundleWorker.Execute` now resolves the revision early in that case and, if a storage backend implements the new interface and reports the same revision is already the latest stored one, skips the rest of the iteration entirely instead of rebuilding from scratch every poll.

`LatestRevision` is implemented for the S3 and GCS backends by reusing their existing metadata-only `HeadObject`/`Attrs` calls (no download required) against the revision they already record on `Upload`. Azure and the local filesystem backend don't currently record a revision this way, so they're left as-is — callers on those backends simply fall back to the existing post-build check (since they don't implement the new optional interface).

## Why draft

Opening as draft to get early feedback on the interface shape (optional capability interface + type assertion vs. adding directly to `ObjectStorage`) before polishing tests/docs further.

## Test plan
- `go build ./...` — clean
- `go vet ./...` — clean
- `golangci-lint run ./internal/s3/... ./pkg/objectstorage/... ./pkg/service/...` — 0 issues
- `go test ./pkg/service/... -run 'TestRevision|TestExtractRevisionRefs|TestResolveRevision|TestBundleWorker'` — passing
- Note: `TestService` and `TestS3` (the httptest-based e2e/integration tests) couldn't be run in my current sandbox (`bind: operation not permitted` for local test listeners, pre-existing/unrelated to this change — confirmed by reproducing the same failure on a clean checkout of `main`). Would appreciate CI running these.
- [ ] Add dedicated unit tests for the new early-skip path in `worker.go` (not yet added — will follow up once the interface shape is agreed on)