### PR TITLE
fix(builder): keep root set minimal in refSet.add

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -509,18 +509,30 @@ type refSet struct {
 	refs []ast.Ref
 }
 
+// add inserts each ref into the set while keeping it minimal: no ref in the
+// set is a prefix of another. Adding a ref already covered by (a prefix of) an
+// existing ref is a no-op; adding a ref that is a prefix of existing refs
+// replaces all of them.
 func (rs *refSet) add(ns ...ast.Ref) {
+next:
 	for _, n := range ns {
-		for i, r := range rs.refs {
-			switch {
-			case r.HasPrefix(n):
-				rs.refs[i] = n
-				return
-			case n.HasPrefix(r):
-				return
+		// If n is already covered by a shorter existing ref, there's nothing
+		// to do for this n.
+		for _, r := range rs.refs {
+			if n.HasPrefix(r) {
+				continue next
 			}
 		}
-		rs.refs = append(rs.refs, n)
+		// Otherwise keep every existing ref that n does not subsume, then add
+		// n. We must drop all refs n is a prefix of, not just the first:
+		// several siblings can be covered by the same shorter prefix.
+		kept := rs.refs[:0]
+		for _, r := range rs.refs {
+			if !r.HasPrefix(n) {
+				kept = append(kept, r)
+			}
+		}
+		rs.refs = append(kept, n)
 	}
 }
 

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -29,8 +29,10 @@ func TestBuilder(t *testing.T) {
 	}
 
 	type sourceMock struct {
-		name          string
-		files         map[string]string
+		name  string
+		files map[string]string
+		// extraFiles are additional filesystems backing the same source.
+		extraFiles    []map[string]string
 		hasDir        bool // create an (empty) directory even without files
 		requirements  []reqMock
 		includedFiles []string
@@ -767,6 +769,73 @@ func TestBuilder(t *testing.T) {
 			exp:      map[string]string{"/data.json": `{"foo":{"bar":{"A":7}}}`},
 			expRoots: []string{"foo/bar"},
 		},
+		{
+			// roots sharing a common prefix must not cause later, unrelated roots to be dropped from the manifest.
+			note: "single source with prefixed and unrelated roots",
+			sources: []sourceMock{
+				{
+					name: "src",
+					files: map[string]string{
+						"/alpha/p.rego": `package alpha
+						p := 1`,
+						"/alpha/c1/p.rego": `package alpha.c1
+						p := 1`,
+						"/alpha/c2/p.rego": `package alpha.c2
+						p := 1`,
+						"/gamma/p.rego": `package gamma
+						p := 1`,
+					},
+				},
+			},
+			exp: map[string]string{
+				"/src/alpha/p.rego": `package alpha
+				p := 1`,
+				"/src/alpha/c1/p.rego": `package alpha.c1
+				p := 1`,
+				"/src/alpha/c2/p.rego": `package alpha.c2
+				p := 1`,
+				"/src/gamma/p.rego": `package gamma
+				p := 1`,
+			},
+			expRoots: []string{"alpha", "gamma"},
+		},
+		{
+			// A source spanning multiple filesystems must not produce
+			// overlapping roots: the second filesystem adds package alpha, a
+			// parent of alpha.c1/alpha.c2 from the first.
+			note: "single source spanning multiple filesystems",
+			sources: []sourceMock{
+				{
+					name: "src",
+					files: map[string]string{
+						"/alpha/c1/p.rego": `package alpha.c1
+						p := 1`,
+						"/alpha/c2/p.rego": `package alpha.c2
+						p := 1`,
+					},
+					extraFiles: []map[string]string{
+						{
+							"/alpha/p.rego": `package alpha
+							p := 1`,
+							"/gamma/p.rego": `package gamma
+							p := 1`,
+						},
+					},
+				},
+			},
+			exp: map[string]string{
+				"/src/alpha/c1/p.rego": `package alpha.c1
+				p := 1`,
+				"/src/alpha/c2/p.rego": `package alpha.c2
+				p := 1`,
+				// second filesystem mounts under src1
+				"/src1/alpha/p.rego": `package alpha
+				p := 1`,
+				"/src1/gamma/p.rego": `package gamma
+				p := 1`,
+			},
+			expRoots: []string{"alpha", "gamma"},
+		},
 	}
 
 	for _, tc := range cases {
@@ -776,6 +845,11 @@ func TestBuilder(t *testing.T) {
 			for i, src := range tc.sources {
 				for k, v := range src.files {
 					allFiles[fmt.Sprintf("src%d/%v", i, k)] = trimLeadingWhitespace(v)
+				}
+				for j, extra := range src.extraFiles {
+					for k, v := range extra {
+						allFiles[fmt.Sprintf("src%d_%d/%v", i, j, k)] = trimLeadingWhitespace(v)
+					}
 				}
 			}
 
@@ -815,6 +889,9 @@ func TestBuilder(t *testing.T) {
 							IncludedFiles: src.includedFiles,
 							ExcludedFiles: src.excludedFiles,
 						})
+					}
+					for j := range src.extraFiles {
+						_ = s.AddDir(builder.Dir{Path: fmt.Sprintf("%v/src%d_%d", root, i, j)})
 					}
 					srcs = append(srcs, s)
 				}


### PR DESCRIPTION
Manifests built by OCP could miss roots for packages present in the bundle, so OPA refuses to load it: 
"error:` bundle bundle.tar.gz: manifest roots [alpha] do not permit 'package gamma' in module '/example-policies/gamma/p.rego'"

refSet.add in pkg/builder/builder.go had two bugs. First, the loop over its args returned on the first ref that overlapped an existing entry, losing every ref after it, which is what drops gamma in the [issue](https://github.com/open-policy-agent/opa-control-plane/issues/279#issuecomment-4746260421). And second, adding a parent of several existing refs replaced only the first child, leaving overlapping roots (i.e. "manifest has overlapped roots: 'alpha' and 'alpha/c2'"), which can happen when there is more than one filesystem, e.g. directory plus git.

This change rewrites the add function to skip refs covered by an existing entry and drop every entry a new ref covers. Replacing the returns with continues (as suggested in the issue thread) would fix the first bug but not the second. Added a regression test per bug. Both fail on the old code with the errors above.

I was looking into this issue a few months ago and totally forgot about it. Appreciate any feedback/review, thank you.

Fixes #279