### PR TITLE
database: propagate the caller's context into every query

### DIFF
--- a/internal/database/bundle_status.go
+++ b/internal/database/bundle_status.go
@@ -202,7 +202,7 @@ func (d *Database) ListBundleStatuses(ctx context.Context, principal, tenant, bu
 			args = []any{tenant, bundleID, limit}
 		}
 
-		rows, err := tx.Query(query, args...)
+		rows, err := tx.QueryContext(ctx, query, args...)
 		if err != nil {
 			return err
 		}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -529,7 +529,7 @@ func sourcesDataGet[T any](ctx context.Context, d *Database, sourceName, path st
 			return zero, false, fmt.Errorf("lookup source name %s: %w", sourceName, err)
 		}
 
-		rows, err := tx.Query(fmt.Sprintf(`SELECT
+		rows, err := tx.QueryContext(ctx, fmt.Sprintf(`SELECT
 	data
 FROM
 	sources_data
@@ -607,7 +607,7 @@ func (d *Database) SourcesDataDelete(ctx context.Context, sourceName, path strin
 			return fmt.Errorf("lookup source name %s: %w", sourceName, err)
 		}
 
-		_, err = tx.Exec(fmt.Sprintf(`DELETE FROM sources_data WHERE source_id = %s AND path = %s AND (`+conditions+")", d.arg(0), d.arg(1)), args...)
+		_, err = tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM sources_data WHERE source_id = %s AND path = %s AND (`+conditions+")", d.arg(0), d.arg(1)), args...)
 		return err
 	})
 }
@@ -802,7 +802,7 @@ LEFT JOIN
     sources ON bundles_requirements.source_id = sources.id
 `, bundles)
 
-		rows, err := txn.Query(query, args...)
+		rows, err := txn.QueryContext(ctx, query, args...)
 		if err != nil {
 			return nil, "", err
 		}
@@ -1095,7 +1095,7 @@ LEFT JOIN
 WHERE (sources_secrets.ref_type = 'git_credentials' OR sources_secrets.ref_type IS NULL)
 `, sources)
 
-		rows, err := txn.Query(query, args...)
+		rows, err := txn.QueryContext(ctx, query, args...)
 		if err != nil {
 			return nil, "", err
 		}
@@ -1226,7 +1226,7 @@ WHERE (sources_secrets.ref_type = 'git_credentials' OR sources_secrets.ref_type 
 
 		// Load datasources for each source.
 
-		rows2, err := txn.Query(`SELECT
+		rows2, err := txn.QueryContext(ctx, `SELECT
 		sources_datasources.name,
 		sources.name,
 		sources_datasources.path,
@@ -1366,7 +1366,7 @@ func (d *Database) ListSecrets(ctx context.Context, principal, tenant string, op
 			args = append(args, opts.Limit)
 		}
 
-		rows, err := txn.Query(query, args...)
+		rows, err := txn.QueryContext(ctx, query, args...)
 		if err != nil {
 			return nil, "", err
 		}
@@ -1485,7 +1485,7 @@ LEFT JOIN
 LEFT JOIN
 	sources ON sources.id = stacks_requirements.source_id
 `, stacks)
-		rows, err := txn.Query(query, args...)
+		rows, err := txn.QueryContext(ctx, query, args...)
 		if err != nil {
 			return nil, "", err
 		}


### PR DESCRIPTION
## Summary

`sql.Tx.Query`, `.Exec` and friends without the `Context` suffix pass `context.Background()` to the driver — [`database/sql/sql.go`](https://github.com/golang/go/blob/master/src/database/sql/sql.go):

```go
func (tx *Tx) Query(query string, args ...any) (*Rows, error) {
	return tx.QueryContext(context.Background(), query, args...)
}
```

Eight queries in `internal/database` use those variants, so they run detached from the caller they belong to, even though each is already inside a method that takes `ctx`.

## Why it matters

- **Cancellation and deadlines don't reach the database.** A client that disconnects, or a request that hits its deadline, leaves these queries running to completion. `ListBundles`/`ListSources` are wide multi-table joins with row fan-out, so the abandoned work is not cheap.
- **A connection-acquisition timeout applied to the caller's context is bypassed** for these queries.
- **Tracing breaks in a way that is actively misleading rather than merely absent.** A span opened around one of these queries has no parent in context, so it's exported as the root of its own trace instead of nesting under the request. A trace of a `GetBundle` call showed only the surrounding transaction's `BEGIN`/`SAVEPOINT`/`RELEASE`/`COMMIT` spans, with a half-second gap where the `SELECT` should have been — the statement *was* traced, just filed under a trace of its own, which is how this was found.

## What changed

Eight call sites switched to the `Context`-taking variants. No behaviour change beyond threading through the `ctx` that was already in scope:

| Location | Method |
|---|---|
| `database.go` | `sourcesDataGet`, `SourcesDataDelete`, `ListBundles`, `ListSources` (main query), `ListSources` (datasources), `ListSecrets`, `ListStacks` |
| `bundle_status.go` | `ListBundleStatuses` |

After this change `grep` finds no remaining non-`Context` `Query`/`Exec`/`QueryRow`/`Prepare` calls in `internal/database`.

## Test plan

- `go build ./...` — clean
- `go vet ./internal/database/...` — clean
- `gofmt -l` — clean
- `go test ./internal/database/...` — the SQLite-backed subtests all pass (72 subtests of `TestDatabase`, 0 failures). The testcontainer-backed dialects (postgres/mysql/cockroachdb) couldn't run in my environment — Docker isn't available, and every failure is a container-startup error, with the failure count matching the "rootless Docker not found" count exactly. Would appreciate CI running those.