### PR TITLE
database: match rows to their tenant by id, not by name

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -2111,9 +2111,13 @@ func (d *Database) upsertReturning(ctx context.Context, returning, returningLast
 				return int(id), nil
 			}
 
+			// Filter on the tenant too: rows are only unique within one, so
+			// without it a same-named row in another tenant matches just as
+			// well, and the caller goes on to write that tenant's rows.
 			var id int
-			query = fmt.Sprintf("SELECT %[1]s.id FROM %[1]s JOIN tenants ON tenants.id = %[1]s.tenant_id AND %[1]s.%[2]s = %[3]s", table, primaryKey[0], d.arg(0))
-			return id, tx.QueryRowContext(ctx, query, values[0]).Scan(&id)
+			query = fmt.Sprintf("SELECT %[1]s.id FROM %[1]s JOIN tenants ON tenants.id = %[1]s.tenant_id WHERE %[1]s.%[2]s = %[3]s AND tenants.name = %[4]s",
+				table, primaryKey[0], d.arg(0), d.arg(1))
+			return id, tx.QueryRowContext(ctx, query, values[0], tenant).Scan(&id)
 		}
 		var id int
 		query += " RETURNING id"

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1224,11 +1224,19 @@ WHERE (sources_secrets.ref_type = 'git_credentials' OR sources_secrets.ref_type 
 			return nil, "", err
 		}
 
-		// Load datasources for each source.
+		// Load datasources for the sources selected above, matched by source id.
 
-		rows2, err := txn.QueryContext(ctx, `SELECT
+		if len(idMap) > 0 {
+			dsArgs := make([]any, 0, len(idMap))
+			byID := make(map[int64]*config.Source, len(idMap))
+			for name, id := range idMap {
+				dsArgs = append(dsArgs, id)
+				byID[id] = srcMap[name]
+			}
+
+			rows2, err := txn.QueryContext(ctx, `SELECT
 		sources_datasources.name,
-		sources.name,
+		sources_datasources.source_id,
 		sources_datasources.path,
 		sources_datasources.type,
 		sources_datasources.config,
@@ -1240,52 +1248,52 @@ WHERE (sources_secrets.ref_type = 'git_credentials' OR sources_secrets.ref_type 
 		sources_datasources
 	LEFT JOIN
 		secrets ON sources_datasources.secret_id = secrets.id
-	LEFT JOIN
-		sources ON sources_datasources.source_id = sources.id
-	`)
-		if err != nil {
-			return nil, "", err
-		}
-
-		defer rows2.Close()
-
-		for rows2.Next() {
-			var name, source_name, path, type_, configuration, transformQuery string
-			var credentialsName, secretName, secretValue sql.NullString
-			if err := rows2.Scan(&name, &source_name, &path, &type_, &configuration, &transformQuery, &credentialsName, &secretName, &secretValue); err != nil {
+	WHERE sources_datasources.source_id IN (`+strings.Join(d.args(len(dsArgs)), ", ")+`)
+	`, dsArgs...)
+			if err != nil {
 				return nil, "", err
 			}
 
-			datasource := config.Datasource{
-				Name:           name,
-				Type:           type_,
-				Path:           path,
-				TransformQuery: transformQuery,
-			}
+			defer rows2.Close()
 
-			if err := json.Unmarshal([]byte(configuration), &datasource.Config); err != nil {
-				return nil, "", err
-			}
-
-			if secretName.Valid && secretValue.Valid {
-				s := config.Secret{Name: secretName.String}
-				if err := json.Unmarshal([]byte(secretValue.String), &s.Value); err != nil {
+			for rows2.Next() {
+				var sourceID int64
+				var name, path, type_, configuration, transformQuery string
+				var credentialsName, secretName, secretValue sql.NullString
+				if err := rows2.Scan(&name, &sourceID, &path, &type_, &configuration, &transformQuery, &credentialsName, &secretName, &secretValue); err != nil {
 					return nil, "", err
 				}
-				datasource.Credentials = s.Ref()
-			} else if credentialsName.Valid {
-				// Secret not in DB but credential name preserved — will be resolved by secret provider at sync time
-				s := config.Secret{Name: credentialsName.String}
-				datasource.Credentials = s.Ref()
-			}
 
-			src, ok := srcMap[source_name]
-			if ok {
-				src.Datasources = append(src.Datasources, datasource)
+				datasource := config.Datasource{
+					Name:           name,
+					Type:           type_,
+					Path:           path,
+					TransformQuery: transformQuery,
+				}
+
+				if err := json.Unmarshal([]byte(configuration), &datasource.Config); err != nil {
+					return nil, "", err
+				}
+
+				if secretName.Valid && secretValue.Valid {
+					s := config.Secret{Name: secretName.String}
+					if err := json.Unmarshal([]byte(secretValue.String), &s.Value); err != nil {
+						return nil, "", err
+					}
+					datasource.Credentials = s.Ref()
+				} else if credentialsName.Valid {
+					// Secret not in DB but credential name preserved — will be resolved by secret provider at sync time
+					s := config.Secret{Name: credentialsName.String}
+					datasource.Credentials = s.Ref()
+				}
+
+				if src, ok := byID[sourceID]; ok {
+					src.Datasources = append(src.Datasources, datasource)
+				}
 			}
-		}
-		if err := rows2.Err(); err != nil {
-			return nil, "", err
+			if err := rows2.Err(); err != nil {
+				return nil, "", err
+			}
 		}
 
 		sl := slices.Collect(maps.Values(srcMap))

--- a/internal/database/sources_tenant_test.go
+++ b/internal/database/sources_tenant_test.go
@@ -1,0 +1,81 @@
+package database_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+
+	"github.com/open-policy-agent/opa-control-plane/internal/migrations"
+	"github.com/open-policy-agent/opa-control-plane/internal/test/dbs"
+	"github.com/open-policy-agent/opa-control-plane/pkg/config"
+)
+
+// TestListSourcesTenantScopesDatasources covers the tenant scoping of the
+// datasource load in ListSources/GetSource. Source names are only unique per
+// tenant (sources has UNIQUE(tenant_id, name)), so two tenants can each own a
+// source called "shared"; the datasources attached to one must never appear on
+// the other's.
+func TestListSourcesTenantScopesDatasources(t *testing.T) {
+	ctx := t.Context()
+
+	const sharedName = "shared"
+
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				t.Cleanup(databaseConfig.Cleanup(t, ctr))
+			}
+
+			db, err := migrations.New().WithConfig(databaseConfig.Database(t, ctr).Database).WithMigrate(true).Run(ctx)
+			require.NoError(t, err)
+			t.Cleanup(db.CloseDB)
+
+			// Two tenants, each with a same-named source carrying a datasource
+			// only it should ever see.
+			for _, tn := range []struct{ tenant, principal, datasource string }{
+				{"tenant-a", "internal:tenant-a", "ds-a"},
+				{"tenant-b", "internal:tenant-b", "ds-b"},
+			} {
+				require.NoError(t, db.UpsertTenantWithPrincipal(ctx, tn.tenant, tn.principal, "administrator"))
+				require.NoError(t, db.UpsertSource(ctx, tn.principal, tn.tenant, &config.Source{
+					Name: sharedName,
+					Git:  config.Git{Repo: "https://example.com/" + tn.tenant},
+					Datasources: config.Datasources{{
+						Name: tn.datasource,
+						Path: tn.datasource,
+						Type: "http",
+					}},
+				}))
+			}
+
+			// Sanity check: both tenants really do have a source under the same
+			// name, otherwise this test would pass without exercising anything.
+			var sources int
+			require.NoError(t, db.DB().QueryRowContext(ctx,
+				"SELECT COUNT(*) FROM sources WHERE name = 'shared'").Scan(&sources))
+			require.Equal(t, 2, sources)
+
+			for _, tc := range []struct{ tenant, principal, want string }{
+				{"tenant-a", "internal:tenant-a", "ds-a"},
+				{"tenant-b", "internal:tenant-b", "ds-b"},
+			} {
+				t.Run(tc.tenant, func(t *testing.T) {
+					src, err := db.GetSource(ctx, tc.principal, tc.tenant, sharedName)
+					require.NoError(t, err)
+
+					got := make([]string, 0, len(src.Datasources))
+					for _, ds := range src.Datasources {
+						got = append(got, ds.Name)
+					}
+					assert.Equal(t, []string{tc.want}, got,
+						"%s must see only its own datasource, not the same-named source's in another tenant", tc.tenant)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two places where a row is looked up by name without regard to which tenant owns
it. Names are only unique per tenant — `sources`, `bundles`, `stacks` and
`secrets` are all `UNIQUE(tenant_id, name)` — so both let one tenant's rows be
attributed to another's.

## 1. `ListSources` attaches datasources by source name

`ListSources` loads each source's datasources in a second query, then attaches
each returned row to a source by looking the row's **source name** up in a map.
That query had **no `WHERE` clause at all**, so:

- it returned `sources_datasources` rows belonging to **every tenant**, and
- a **name**-keyed match could not tell them apart.

Two tenants that each own a source called the same thing therefore saw **each
other's datasources**, including the credentials those datasources reference.
`GetSource` is affected too, since it is implemented in terms of `ListSources`.

The same missing `WHERE` clause also meant every call read — and JSON-decoded,
including secret values — every datasource of every tenant, then discarded all
but the matching rows in Go, so the work grew with the size of the whole table
rather than with the page being returned.

**Fix:** scope the query to the ids of the sources the query above already
selected, and key the match on `sources_datasources.source_id` instead of the
joined source name. Matching on the id is the part that matters: it keeps the
association right *independent of* the `WHERE` clause, so a later change to the
filter can't quietly reintroduce the leak. It also makes the `LEFT JOIN sources`
unnecessary, since that join existed only to produce the name used for the
lookup.

## 2. `upsert`'s MySQL id lookup ignores the tenant

`upsert` returns the affected row's id. On MySQL, which has no `RETURNING`, it
gets that id with a follow-up `SELECT` — and that `SELECT` joined `tenants`
without ever filtering on one:

```sql
SELECT sources.id FROM sources
  JOIN tenants ON tenants.id = sources.tenant_id AND sources.name = ?
```

With two tenants owning a row of the same name, this returns whichever the
database happens to pick, and the caller then writes the *other* tenant's rows.
`UpsertSource` inserts the source's datasources against the id it was handed, so
a second tenant's datasources land on the first tenant's source — leaving the
second tenant's source with none.

**Fix:** add the tenant to the filter. Only `upsert` reaches this path
(`upsertRel` and `upsertNoID` pass `returning=false`) and all five of its callers
pass a real tenant, so no special case is needed for the relation-only tables.

## How this was found

The added test creates two tenants that each own a source named `shared`, each
with one datasource, and asserts each tenant sees only its own.

Before fix 1, on every dialect:

```
tenant-a: expected ["ds-a"], actual ["ds-a", "ds-b"]
tenant-b: expected ["ds-b"], actual ["ds-a", "ds-b"]
```

With fix 1 but not fix 2, CI surfaced the second bug on MySQL, in the shape that
distinguishes it — one tenant holding both datasources, the other holding none:

```
tenant-a: expected ["ds-a"], actual ["ds-a", "ds-b"]
tenant-b: expected ["ds-b"], actual []
```

The existing `internal/database` tests all run against a single tenant
(`"default"`), which is why neither bug had been caught.

## Test plan

- `go build ./...`, `go vet ./internal/database/...`, `gofmt -l` — clean
- `go test ./internal/database/...` — SQLite-backed subtests pass (72 subtests of
  `TestDatabase`, 0 failures), and the new test fails without fix 1 and passes
  with it
- The testcontainer dialects (postgres/mysql/cockroachdb) can't run in my
  environment — no Docker daemon — so **fix 2 is verified only by CI**, which is
  also what caught the bug. The postgres/cockroach paths use `RETURNING` and are
  unaffected by that change.