### PR TITLE
migrations: index bundles_statuses by bundle_id

### DIFF
--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -46,6 +46,7 @@ func Migrations(dialect string) (fs.FS, error) {
 		addSourcesGitCredentialsName(25, dialect),
 		addBundlesStatuses(26, dialect),
 		addBundlesStatusesUpdatedAt(27, dialect), // adds 2, next is 29.
+		addBundlesStatusesBundleIDIndex(29, dialect),
 	), nil
 }
 

--- a/internal/migrations/migrations_next.go
+++ b/internal/migrations/migrations_next.go
@@ -120,6 +120,44 @@ func addBundlesStatusesUpdatedAt(offset int, dialect string) fs.FS {
 	})
 }
 
+// addBundlesStatusesBundleIDIndex indexes bundles_statuses by bundle_id.
+//
+// Every lookup of a bundle's statuses filters on bundle_id, either directly
+// (ListBundleStatuses, and the two DELETEs UpsertBundleStatus runs to drop the
+// pre-revision sentinel row and to enforce the retention limit) or via the
+// ON DELETE CASCADE from bundles. None of them could use an index: the only
+// candidate was UNIQUE(tenant_id, bundle_id, revision), whose leading column is
+// tenant_id, so each of those statements scanned the table instead -- a delete
+// of a single bundle was reading hundreds of rows.
+//
+// tenant_id is stored in the index rather than left out because deleting a row
+// also means removing its entry from UNIQUE(tenant_id, bundle_id, revision),
+// which needs the tenant_id; storing it here avoids a second lookup against the
+// primary index to fetch it. Dialects spell that differently, and SQLite and
+// MySQL have no equivalent -- MySQL gets tenant_id as a trailing key column,
+// which covers the same reads, and SQLite is dev/test only.
+func addBundlesStatusesBundleIDIndex(offset int, dialect string) fs.FS {
+	var stmt string
+	switch dialect {
+	case "cockroachdb":
+		stmt = `CREATE INDEX bundles_statuses_bundle_id_revision_idx
+			ON bundles_statuses (bundle_id, revision) STORING (tenant_id)`
+	case "postgresql":
+		stmt = `CREATE INDEX bundles_statuses_bundle_id_revision_idx
+			ON bundles_statuses (bundle_id, revision) INCLUDE (tenant_id)`
+	case "mysql":
+		stmt = `CREATE INDEX bundles_statuses_bundle_id_revision_idx
+			ON bundles_statuses (bundle_id, revision, tenant_id)`
+	case "sqlite":
+		stmt = `CREATE INDEX bundles_statuses_bundle_id_revision_idx
+			ON bundles_statuses (bundle_id, revision)`
+	}
+
+	return ocp_fs.MapFS(map[string]string{
+		fmt.Sprintf("%03d_add_bundles_statuses_bundle_id_index.up.sql", offset): stmt,
+	})
+}
+
 // NOTE(sr): We create new tables to drop constraints. It's hard to predict constraint names
 // across MySQL and Postgres if they have not been set up at creation time.
 // NOTE(sr): We want this to work, or fail, in one step. So this will all be done in a single migration,


### PR DESCRIPTION
## Summary

Every lookup of a bundle's statuses filters on `bundle_id`, and none of them could use an index.

The only candidate index was `UNIQUE(tenant_id, bundle_id, revision)`, whose **leading column is `tenant_id`** — which none of these statements constrain. So each of them scanned the table instead:

| Statement | Filter |
|---|---|
| `ListBundleStatuses` | `tenants.name = ? AND bundle_id = ?` (joins `tenants`, so `tenant_id` isn't an equality constraint) |
| `UpsertBundleStatus` — drop stale sentinel | `bundle_id = ? AND revision = ?` |
| `UpsertBundleStatus` — retention cleanup | `bundle_id = ? AND id < ?` |
| `DELETE FROM bundles` | via `ON DELETE CASCADE` on `bundles_statuses.bundle_id` |

## What this cost in practice

Measured on a production CockroachDB cluster over a six-hour window, for the retention-cleanup `DELETE`:

| | |
|---|---|
| Rows read per execution | **~258** (to delete one row) |
| Executions | **21.1k** |
| Mean statement time | **1.5 s** |
| **Contention time** | **1.4 s** (93%) |
| SQL CPU time | ~200 µs |
| Full scan | yes |
| Failures | 831, all `40001` (`ABORT_REASON_PUSHER_ABORTED`) |

The contention is the interesting part, and it's a consequence of the scan rather than of load: a scan takes locks across the whole table, so every execution collided with the writes the build workers were concurrently making to `bundles_statuses`. The statement's own CPU time being ~200 µs rules out the work itself being expensive. Deleting a bundle showed the same scan through the cascade.

CockroachDB's own index recommendation for that statement was exactly this index, including the `STORING` clause.

## On `STORING (tenant_id)`

Deleting a row also means removing its entry from `UNIQUE(tenant_id, bundle_id, revision)`, which needs the `tenant_id`. Carrying it in the index avoids a second lookup against the primary index just to fetch it.

Dialects spell this differently, and two have no equivalent:

| Dialect | Statement |
|---|---|
| CockroachDB | `... (bundle_id, revision) STORING (tenant_id)` |
| PostgreSQL | `... (bundle_id, revision) INCLUDE (tenant_id)` |
| MySQL | `... (bundle_id, revision, tenant_id)` — trailing key column, covers the same reads |
| SQLite | `... (bundle_id, revision)` — dev/test only |


## Second commit: `bundles_requirements`/`stacks_requirements`/`sources_requirements`

Same root cause, three more tables, found via CRDB's index recommendations for `DeleteSource`:

`DeleteSource` deliberately doesn't clean out `bundles_requirements` or `stacks_requirements` — it relies on their `FOREIGN KEY (source_id) REFERENCES sources(id)` to reject the delete if a requirement still points at the source (`// NB(sr): We do not clean out stacks_requirements and bundles_requirements: that'll ensure that only unused sources can be deleted.`). `sources_requirements` runs the equivalent check on `requirement_id` when a source is required by another source.

All three checks filter on a column that isn't the leading column of any index on these tables — `PrimaryKey` put the other referencing column first:

| Table | Primary key | FK check filters on |
|---|---|---|
| `bundles_requirements` | `(bundle_id, source_id)` | `source_id` (2nd column) |
| `stacks_requirements` | `(stack_id, source_id)` | `source_id` (2nd column) |
| `sources_requirements` | `(source_id, requirement_id)` | `requirement_id` (2nd column) |

So every `DELETE FROM sources` — whether it succeeds or gets rejected by the constraint — scans all three tables to answer "does anything reference this id". These are plain single-column indexes, no `STORING` needed: unlike `bundles_statuses`, nothing here needs covering, just a leading column to seek on.

## Test plan

- `go build ./...`, `go vet ./internal/migrations/... ./internal/database/...`, `gofmt -l` — clean
- `go test ./internal/database/...` — the SQLite-backed subtests apply both migrations for real: 72 subtests of `TestDatabase` pass, 0 failures
- The testcontainer dialects (postgres/mysql/cockroachdb) can't run in my environment — no Docker daemon — so those three `CREATE INDEX` variants are verified only by CI.
