### PR TITLE
build: ignore OPA dep for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,8 @@ updates:
       all:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "github.com/open-policy-agent/opa"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Dependabot wants to upgrade to OPA v1.20.2, but that'll downgrade the dep github.com/gobwas/glob, and make the build fail again.

Remove once we've got an OPA release using gobwas/glob 1.0.0, probably OPA v1.21.0.

------

This will fix the dependabot PRs -- they're currently red because of this.