### PR TITLE
migrations: cover the columns ListSources selects

### DIFF
--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -46,6 +46,7 @@ func Migrations(dialect string) (fs.FS, error) {
 		addSourcesGitCredentialsName(25, dialect),
 		addBundlesStatuses(26, dialect),
 		addBundlesStatusesUpdatedAt(27, dialect), // adds 2, next is 29.
+		addSourcesTenantIDIndex(29, dialect),
 	), nil
 }
 

--- a/internal/migrations/migrations_next.go
+++ b/internal/migrations/migrations_next.go
@@ -120,6 +120,45 @@ func addBundlesStatusesUpdatedAt(offset int, dialect string) fs.FS {
 	})
 }
 
+// addSourcesTenantIDIndex covers the columns ListSources selects, so listing a
+// tenant's sources doesn't have to go back to the primary index per row.
+//
+// ListSources (and GetSource, which is a list with the name pinned) selects
+// every source column but tenant_id. The only index it can use is
+// UNIQUE(tenant_id, name), which holds just those two columns plus the primary
+// key, so the planner seeks it for the tenant and then joins back to the
+// primary index for the rest -- once per row. In production that statement
+// averaged 128 rows read to return a source.
+//
+// The key is tenant_id alone rather than (tenant_id, name): a secondary index
+// implicitly carries the primary key, so this orders as (tenant_id, id), which
+// is exactly the WHERE tenant_id = ? ... ORDER BY sources.id that the query
+// asks for. Adding name in front would order by name instead and leave the sort
+// to be done separately.
+//
+// Only CockroachDB and PostgreSQL get the covering columns; MySQL stores these
+// as TEXT, which can't go in an index key without a prefix length, and SQLite
+// has no equivalent of STORING. Both keep UNIQUE(tenant_id, name) for the seek
+// and pay the lookup, which is what they do today.
+func addSourcesTenantIDIndex(offset int, dialect string) fs.FS {
+	const covering = `name, builtin, repo, ref, gitcommit, path,
+		git_included_files, git_excluded_files, git_credentials_name`
+
+	var stmt string
+	switch dialect {
+	case "cockroachdb":
+		stmt = `CREATE INDEX sources_tenant_id_idx ON sources (tenant_id) STORING (` + covering + `)`
+	case "postgresql":
+		stmt = `CREATE INDEX sources_tenant_id_idx ON sources (tenant_id) INCLUDE (` + covering + `)`
+	case "mysql", "sqlite":
+		stmt = `CREATE INDEX sources_tenant_id_idx ON sources (tenant_id)`
+	}
+
+	return ocp_fs.MapFS(map[string]string{
+		fmt.Sprintf("%03d_add_sources_tenant_id_index.up.sql", offset): stmt,
+	})
+}
+
 // NOTE(sr): We create new tables to drop constraints. It's hard to predict constraint names
 // across MySQL and Postgres if they have not been set up at creation time.
 // NOTE(sr): We want this to work, or fail, in one step. So this will all be done in a single migration,


### PR DESCRIPTION
## Why

`ListSources` — and `GetSource`, which goes through it with the name pinned — selects every `sources` column except `tenant_id`. The only index available is `UNIQUE(tenant_id, name)`, which holds those two columns plus the primary key. So the planner seeks it for the tenant and then joins back to the primary index for the remaining nine columns, **once per row**.

From a production CockroachDB console, on that statement:

```
Full Scan                Yes
Average Rows Read        128.2
Average Execution Time   276.9 ms
Execution Count (6h)     19.5 k
Used Indexes             sources: ocp_v2_sources_tenant_id_name_unique,
                                  ocp_v2_sources_id_pkey        ← the lookup join
```

Reading 128 rows to return one source is the second lookup, per row. The console's own index recommendation for this statement was:

```sql
CREATE INDEX ON sources (tenant_id) STORING (name, builtin, repo, ref, gitcommit,
  path, git_included_files, git_excluded_files, git_credentials_name);
```

That's what this adds.

## What changed

One migration, `029_add_sources_tenant_id_index`:

```sql
-- cockroachdb
CREATE INDEX sources_tenant_id_idx ON sources (tenant_id) STORING (name, builtin, repo,
  ref, gitcommit, path, git_included_files, git_excluded_files, git_credentials_name)

-- postgresql   (same, INCLUDE instead of STORING)
-- mysql, sqlite
CREATE INDEX sources_tenant_id_idx ON sources (tenant_id)
```

**Why `tenant_id` alone is the key.** A secondary index implicitly carries the primary key, so this orders as `(tenant_id, id)` — which is exactly the `WHERE tenant_id = ? … ORDER BY sources.id` the query asks for. Putting `name` in front would order by name and leave the sort to be done separately.

**Why MySQL and SQLite only get the key.** MySQL stores these columns as `TEXT`, which needs a prefix length to sit in an index key, and SQLite has no equivalent of `STORING`/`INCLUDE`. Both keep `UNIQUE(tenant_id, name)` for the seek and continue paying the lookup, exactly as they do today — no regression, just no gain.

## Testing

- [x] `go build ./...` clean
- [x] Generated DDL inspected for all four dialects
- [x] `TestDatabase/sqlite-memory-only` and `/sqlite-persistence` pass — these exercise `ListSources`, so the migration chain applies and the index doesn't break the query
- [x] `gofmt` clean
- [ ] Postgres / MySQL / CockroachDB paths — **CI only**, see Notes
- [ ] Post-deploy: re-check rows read and execution time on the same statement

## Notes

⚠️ **I could not run the non-SQLite tests locally** — they need testcontainers, and Docker isn't available in my environment. The SQLite path passes, but the dialect-specific DDL (`STORING` / `INCLUDE` / bare key) is only exercised by CI. Please don't merge on a green SQLite run alone.

⚠️ **Migration number collides with #407.** Both take 29, since both branch from the current main (28 is the last applied). Whichever lands first keeps 29; I'll rebase the other to 30. They're otherwise independent — different table, different query.

⚠️ **Storage cost.** The index stores every column except `tenant_id`, so it roughly duplicates the table. Sources are configuration data and rarely written, so the write amplification should be minor, but the storage is real and worth a look on a large install.

⚠️ **This addresses the lookup, not the scan.** The same statement's plan also shows FULL SCAN over `sources_secrets`, `sources_requirements` and `secrets` — those come from the LEFT JOINs and are untouched here. Splitting those joins into keyed lookups (the shape a2919ea used for datasources) is a separate, larger change; I'd rather land this one first and re-measure before deciding whether the rest is still worth it.
