### PR TITLE
fix: data sources with same name but different paths overriding data

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1815,7 +1815,7 @@ func (d *Database) UpsertSource(ctx context.Context, principal, tenant string, s
 				// If secret not found in DB (sql.ErrNoRows), skip — it will be resolved by the secret provider at sync time
 			}
 			if err := d.upsertRel(ctx, tx, "sources_datasources", []string{"source_id", "name", "type", "path", "config", "transform_query", "secret_id", "credentials_name"},
-				[]string{"source_id", "name"},
+				[]string{"source_id", "name", "path"},
 				id, datasource.Name, datasource.Type, datasource.Path, string(bs), datasource.TransformQuery, secret, credentialsName); err != nil {
 				return fmt.Errorf("upsert of datasource link %s: %w", datasource.Name, err)
 			}

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -575,6 +575,48 @@ func TestDatabase(t *testing.T) {
 						},
 					}),
 
+				newTestCase("upsert source with datasources sharing name but different path").
+					UpsertSource(&config.Source{
+						Name: "dup-name-ds",
+						Datasources: config.Datasources{
+							{
+								Name: "duplicate",
+								Type: "http",
+								Config: map[string]any{
+									"url": "https://example.com/a",
+								},
+							},
+							{
+								Name: "duplicate",
+								Path: "subpath",
+								Type: "http",
+								Config: map[string]any{
+									"url": "https://example.com/b",
+								},
+							},
+						},
+					}).
+					GetSource("dup-name-ds", &config.Source{
+						Name: "dup-name-ds",
+						Datasources: config.Datasources{
+							{
+								Name: "duplicate",
+								Type: "http",
+								Config: map[string]any{
+									"url": "https://example.com/a",
+								},
+							},
+							{
+								Name: "duplicate",
+								Path: "subpath",
+								Type: "http",
+								Config: map[string]any{
+									"url": "https://example.com/b",
+								},
+							},
+						},
+					}),
+
 				// Run last, and after an explicit wait: CockroachDB follower
 				// reads (ListOptions.Stale) read a fixed point a few seconds
 				// in the past, which must be after the migrations that

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -46,6 +46,7 @@ func Migrations(dialect string) (fs.FS, error) {
 		addSourcesGitCredentialsName(25, dialect),
 		addBundlesStatuses(26, dialect),
 		addBundlesStatusesUpdatedAt(27, dialect), // adds 2, next is 29.
+		fixDatasourcesPrimaryKey(29, dialect),    // adds 4, next is 33.
 	), nil
 }
 

--- a/internal/migrations/migrations_next.go
+++ b/internal/migrations/migrations_next.go
@@ -120,6 +120,53 @@ func addBundlesStatusesUpdatedAt(offset int, dialect string) fs.FS {
 	})
 }
 
+// fixDatasourcesPrimaryKey widens the primary key of sources_datasources from
+// (source_id, name) to (source_id, name, path). Without "path" in the key,
+// two datasources sharing the same "name" but different "path" values collapse
+// into a single row on upsert, silently dropping one of them. Since none of our
+// dialects support altering a primary key in place, we recreate the table with
+// the new key, copy the data across, and drop the old table. The four steps are
+// split into separate migrations (rather than one multi-statement transaction)
+// because CockroachDB's async schema changer rejects DML against a table that
+// was just created earlier in the same transaction.
+func fixDatasourcesPrimaryKey(offset int, dialect string) fs.FS {
+	var kind int
+	switch dialect {
+	case "postgresql":
+		kind = postgres
+	case "mysql":
+		kind = mysql
+	case "sqlite":
+		kind = sqlite
+	case "cockroachdb":
+		kind = cockroachdb
+	}
+
+	newTbl := createSQLTable("sources_datasources").
+		WithIteration("ocp_v2_pkfix"). // distinct from "ocp_v2" to avoid clashing with the old table's constraint names while both exist during the migration
+		VarCharNonNullColumn("name").
+		IntegerNonNullColumn("source_id").
+		IntegerColumn("secret_id"). // optional
+		TextNonNullColumn("type").
+		VarCharNonNullColumn("path"). // part of the primary key; needs a bounded length for MySQL
+		TextNonNullColumn("config").
+		TextNonNullColumn("transform_query").
+		TextColumn("credentials_name").
+		PrimaryKey("source_id", "name", "path").
+		ForeignKey("secret_id", "secrets(id)").
+		ForeignKey("source_id", "sources(id)")
+
+	const oldName = "sources_datasources_old"
+	cols := "name, source_id, secret_id, type, path, config, transform_query, credentials_name"
+
+	return ocp_fs.MapFS(map[string]string{
+		fmt.Sprintf("%03d_fix_datasources_primary_key_rename.up.sql", offset):   "ALTER TABLE sources_datasources RENAME TO " + oldName,
+		fmt.Sprintf("%03d_fix_datasources_primary_key_create.up.sql", offset+1): strings.TrimRight(newTbl.SQL(kind), ";"),
+		fmt.Sprintf("%03d_fix_datasources_primary_key_copy.up.sql", offset+2):   fmt.Sprintf(`INSERT INTO sources_datasources (%[1]s) SELECT %[1]s FROM %[2]s`, cols, oldName),
+		fmt.Sprintf("%03d_fix_datasources_primary_key_drop.up.sql", offset+3):   "DROP TABLE " + oldName,
+	})
+}
+
 // NOTE(sr): We create new tables to drop constraints. It's hard to predict constraint names
 // across MySQL and Postgres if they have not been set up at creation time.
 // NOTE(sr): We want this to work, or fail, in one step. So this will all be done in a single migration,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -707,8 +707,12 @@ func (d *Datasource) Equal(other *Datasource) bool {
 	})
 }
 
+// datasourceKey uniquely identifies a Datasource within a Source: Name alone is not
+// unique, since multiple datasources may share a Name as long as their Path differs.
+type datasourceKey struct{ name, path string }
+
 func (a Datasources) Equal(b Datasources) bool {
-	return internalutil.SetEqual(a, b, func(ds Datasource) string { return ds.Name }, func(a, b Datasource) bool { return a.Equal(&b) })
+	return internalutil.SetEqual(a, b, func(ds Datasource) datasourceKey { return datasourceKey{ds.Name, ds.Path} }, func(a, b Datasource) bool { return a.Equal(&b) })
 }
 
 // DatabaseConfig configures the OCP database connection.


### PR DESCRIPTION
## Fix: data sources with the same `name` but different `path` silently overwrite each other

Fixes #416

### Changes
- Widen `sources_datasources` primary key to `(source_id, name, path)` via new migration (recreate table across sqlite/postgres/mysql/cockroachdb).
- Update `UpsertSource`'s conflict key to `(source_id, name, path)`.
- Fix `Datasources.Equal` to key by `(Name, Path)` instead of `Name` alone.
- Add regression test covering two datasources with the same name but different paths.

### Testing
- `go test ./...` (sqlite, postgres, mysql, cockroachdb via testcontainers) — all pass.
