### PR TITLE
database: split the list joins into keyed lookups

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1073,29 +1073,7 @@ WHERE (` + conditions + ") AND tenants.name = " + d.arg(len(args))
 			args = append(args, opts.Limit)
 		}
 
-		query := fmt.Sprintf(`SELECT
-	sources.*,
-	secrets.name AS secret_name,
-	sources_secrets.ref_type,
-	secrets.value,
-	required_sources.name,
-	sources_requirements.gitcommit,
-	sources_requirements.path,
-	sources_requirements.prefix,
-	sources_requirements.options
-FROM (%s) AS sources
-LEFT JOIN
-	sources_secrets ON sources.id = sources_secrets.source_id
-LEFT JOIN
-	secrets ON sources_secrets.secret_id = secrets.id
-LEFT JOIN
-	sources_requirements ON sources.id = sources_requirements.source_id
-LEFT JOIN
-    sources AS required_sources ON required_sources.id = sources_requirements.requirement_id
-WHERE (sources_secrets.ref_type = 'git_credentials' OR sources_secrets.ref_type IS NULL)
-`, sources)
-
-		rows, err := txn.QueryContext(ctx, query, args...)
+		rows, err := txn.QueryContext(ctx, sources, args...)
 		if err != nil {
 			return nil, "", err
 		}
@@ -1108,10 +1086,6 @@ WHERE (sources_secrets.ref_type = 'git_credentials' OR sources_secrets.ref_type 
 			repo                                             string
 			ref, gitCommit, path, includePaths, excludePaths *string
 			gitCredentialsName                               *string
-			secretName, secretRefType, secretValue           *string
-			requirementName, requirementCommit               *string
-			reqPath, reqPrefix                               sql.Null[string]
-			reqOpts                                          sql.Null[string] // JSON
 		}
 
 		srcMap := make(map[string]*config.Source)
@@ -1130,90 +1104,46 @@ WHERE (sources_secrets.ref_type = 'git_credentials' OR sources_secrets.ref_type 
 				&row.includePaths,
 				&row.excludePaths,
 				&row.gitCredentialsName,
-				&row.secretName,
-				&row.secretRefType,
-				&row.secretValue,
-				&row.requirementName,
-				&row.requirementCommit,
-				&row.reqPath,
-				&row.reqPrefix,
-				&row.reqOpts,
 			); err != nil {
 				return nil, "", err
 			}
 
-			src, exists := srcMap[row.sourceName]
-			if !exists {
-				src = &config.Source{
-					ID:      row.id,
-					Name:    row.sourceName,
-					Builtin: row.builtin,
-					Git: config.Git{
-						Repo: row.repo,
-					},
-				}
-				srcMap[row.sourceName] = src
-				idMap[row.sourceName] = row.id
+			src := &config.Source{
+				ID:      row.id,
+				Name:    row.sourceName,
+				Builtin: row.builtin,
+				Git: config.Git{
+					Repo: row.repo,
+				},
+			}
+			srcMap[row.sourceName] = src
+			idMap[row.sourceName] = row.id
 
-				if row.ref != nil {
-					src.Git.Reference = row.ref
+			if row.ref != nil {
+				src.Git.Reference = row.ref
+			}
+			if row.gitCommit != nil {
+				src.Git.Commit = row.gitCommit
+			}
+			if row.path != nil {
+				src.Git.Path = row.path
+			}
+			if row.includePaths != nil {
+				if err := json.Unmarshal([]byte(*row.includePaths), &src.Git.IncludedFiles); err != nil {
+					return nil, "", fmt.Errorf("failed to unmarshal include paths for %q: %w", src.Name, err)
 				}
-				if row.gitCommit != nil {
-					src.Git.Commit = row.gitCommit
-				}
-				if row.path != nil {
-					src.Git.Path = row.path
-				}
-				if row.includePaths != nil {
-					if err := json.Unmarshal([]byte(*row.includePaths), &src.Git.IncludedFiles); err != nil {
-						return nil, "", fmt.Errorf("failed to unmarshal include paths for %q: %w", src.Name, err)
-					}
-				}
-				if row.excludePaths != nil {
-					if err := json.Unmarshal([]byte(*row.excludePaths), &src.Git.ExcludedFiles); err != nil {
-						return nil, "", fmt.Errorf("failed to unmarshal exclude paths for %q: %w", src.Name, err)
-					}
+			}
+			if row.excludePaths != nil {
+				if err := json.Unmarshal([]byte(*row.excludePaths), &src.Git.ExcludedFiles); err != nil {
+					return nil, "", fmt.Errorf("failed to unmarshal exclude paths for %q: %w", src.Name, err)
 				}
 			}
 
-			if row.secretRefType != nil && *row.secretRefType == "git_credentials" && row.secretName != nil {
-				s := config.Secret{Name: *row.secretName}
-				if row.secretValue != nil {
-					if err := json.Unmarshal([]byte(*row.secretValue), &s.Value); err != nil {
-						return nil, "", err
-					}
-				}
-				src.Git.Credentials = s.Ref()
-			} else if row.gitCredentialsName != nil {
+			// A row in sources_secrets takes precedence over this, and overwrites
+			// it below if one exists.
+			if row.gitCredentialsName != nil {
 				s := config.Secret{Name: *row.gitCredentialsName}
 				src.Git.Credentials = s.Ref()
-			}
-
-			if row.requirementName != nil {
-				var automount *bool
-				if row.reqOpts.Valid {
-					var m map[string]any
-					if err := json.Unmarshal([]byte(row.reqOpts.V), &m); err != nil {
-						return nil, "", fmt.Errorf("failed to unmarshal options for requirement %s of source %s: %w", *row.requirementName, row.sourceName, err)
-					}
-					if am, ok := m["automount"]; ok {
-						if am, ok := am.(bool); ok {
-							automount = &am
-							delete(m, "automount")
-						}
-					}
-					if len(m) > 0 {
-						return nil, "", fmt.Errorf("unknown options for requirement %s of source %s: %v", *row.requirementName, row.sourceName, m)
-					}
-
-				}
-				src.Requirements = append(src.Requirements, config.Requirement{
-					Source:    row.requirementName,
-					Git:       config.GitRequirement{Commit: row.requirementCommit},
-					Path:      row.reqPath.V,
-					Prefix:    row.reqPrefix.V,
-					AutoMount: automount,
-				})
 			}
 
 			if row.id > last {
@@ -1224,16 +1154,125 @@ WHERE (sources_secrets.ref_type = 'git_credentials' OR sources_secrets.ref_type 
 			return nil, "", err
 		}
 
-		// Load datasources for the sources selected above, matched by source id.
+		// The remaining attributes hang off the sources selected above, matched by
+		// source id. Each is its own statement rather than a join: the ids are
+		// literals here, so the planner can seek on the leading primary-key column
+		// instead of estimating how many rows the source query returns and falling
+		// back to a hash join over the whole table.
 
-		if len(idMap) > 0 {
-			dsArgs := make([]any, 0, len(idMap))
-			byID := make(map[int64]*config.Source, len(idMap))
-			for name, id := range idMap {
-				dsArgs = append(dsArgs, id)
-				byID[id] = srcMap[name]
+		var srcArgs []any
+		byID := make(map[int64]*config.Source, len(idMap))
+		for name, id := range idMap {
+			srcArgs = append(srcArgs, id)
+			byID[id] = srcMap[name]
+		}
+		idList := strings.Join(d.args(len(srcArgs)), ", ")
+
+		if len(srcArgs) > 0 {
+			rowsSecrets, err := txn.QueryContext(ctx, `SELECT
+		sources_secrets.source_id,
+		secrets.name,
+		secrets.value
+	FROM sources_secrets
+	JOIN secrets ON sources_secrets.secret_id = secrets.id
+	WHERE sources_secrets.ref_type = 'git_credentials'
+	  AND sources_secrets.source_id IN (`+idList+`)
+	`, srcArgs...)
+			if err != nil {
+				return nil, "", err
+			}
+			defer rowsSecrets.Close()
+
+			for rowsSecrets.Next() {
+				var sourceID int64
+				var secretName string
+				var secretValue *string
+				if err := rowsSecrets.Scan(&sourceID, &secretName, &secretValue); err != nil {
+					return nil, "", err
+				}
+
+				src, ok := byID[sourceID]
+				if !ok {
+					continue
+				}
+
+				s := config.Secret{Name: secretName}
+				if secretValue != nil {
+					if err := json.Unmarshal([]byte(*secretValue), &s.Value); err != nil {
+						return nil, "", err
+					}
+				}
+				src.Git.Credentials = s.Ref()
+			}
+			if err := rowsSecrets.Err(); err != nil {
+				return nil, "", err
 			}
 
+			rowsReqs, err := txn.QueryContext(ctx, `SELECT
+		sources_requirements.source_id,
+		required_sources.name,
+		sources_requirements.gitcommit,
+		sources_requirements.path,
+		sources_requirements.prefix,
+		sources_requirements.options
+	FROM sources_requirements
+	JOIN sources AS required_sources ON required_sources.id = sources_requirements.requirement_id
+	WHERE sources_requirements.source_id IN (`+idList+`)
+	ORDER BY sources_requirements.source_id, sources_requirements.requirement_id
+	`, srcArgs...)
+			if err != nil {
+				return nil, "", err
+			}
+			defer rowsReqs.Close()
+
+			for rowsReqs.Next() {
+				var sourceID int64
+				var requirementName string
+				var requirementCommit *string
+				var reqPath, reqPrefix sql.Null[string]
+				var reqOpts sql.Null[string] // JSON
+				if err := rowsReqs.Scan(&sourceID, &requirementName, &requirementCommit, &reqPath, &reqPrefix, &reqOpts); err != nil {
+					return nil, "", err
+				}
+
+				src, ok := byID[sourceID]
+				if !ok {
+					continue
+				}
+
+				var automount *bool
+				if reqOpts.Valid {
+					var m map[string]any
+					if err := json.Unmarshal([]byte(reqOpts.V), &m); err != nil {
+						return nil, "", fmt.Errorf("failed to unmarshal options for requirement %s of source %s: %w", requirementName, src.Name, err)
+					}
+					if am, ok := m["automount"]; ok {
+						if am, ok := am.(bool); ok {
+							automount = &am
+							delete(m, "automount")
+						}
+					}
+					if len(m) > 0 {
+						return nil, "", fmt.Errorf("unknown options for requirement %s of source %s: %v", requirementName, src.Name, m)
+					}
+				}
+
+				src.Requirements = append(src.Requirements, config.Requirement{
+					Source:    &requirementName,
+					Git:       config.GitRequirement{Commit: requirementCommit},
+					Path:      reqPath.V,
+					Prefix:    reqPrefix.V,
+					AutoMount: automount,
+				})
+			}
+			if err := rowsReqs.Err(); err != nil {
+				return nil, "", err
+			}
+		}
+
+		// Load datasources for the sources selected above, matched by source id.
+
+		if len(srcArgs) > 0 {
 			rows2, err := txn.QueryContext(ctx, `SELECT
 		sources_datasources.name,
 		sources_datasources.source_id,
@@ -1248,8 +1287,8 @@ WHERE (sources_secrets.ref_type = 'git_credentials' OR sources_secrets.ref_type 
 		sources_datasources
 	LEFT JOIN
 		secrets ON sources_datasources.secret_id = secrets.id
-	WHERE sources_datasources.source_id IN (`+strings.Join(d.args(len(dsArgs)), ", ")+`)
-	`, dsArgs...)
+	WHERE sources_datasources.source_id IN (`+idList+`)
+	`, srcArgs...)
 			if err != nil {
 				return nil, "", err
 			}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -782,27 +782,7 @@ WHERE (` + conditions + ") AND tenants.name = " + d.arg(len(args))
 			args = append(args, opts.Limit)
 		}
 
-		query := fmt.Sprintf(`SELECT
-		bundles.*,
-		secrets.name AS secret_name,
-		secrets.value AS secret_value,
-		sources.name AS req_src,
-		bundles_requirements.path AS req_path,
-		bundles_requirements.prefix AS req_prefix,
-		bundles_requirements.options AS req_options,
-		bundles_requirements.gitcommit AS req_commit
-FROM (%s) AS bundles
-LEFT JOIN
-    bundles_secrets ON bundles.id = bundles_secrets.bundle_id
-LEFT JOIN
-    secrets ON bundles_secrets.secret_id = secrets.id
-LEFT JOIN
-	bundles_requirements ON bundles.id = bundles_requirements.bundle_id
-LEFT JOIN
-    sources ON bundles_requirements.source_id = sources.id
-`, bundles)
-
-		rows, err := txn.QueryContext(ctx, query, args...)
+		rows, err := txn.QueryContext(ctx, bundles, args...)
 		if err != nil {
 			return nil, "", err
 		}
@@ -820,10 +800,6 @@ LEFT JOIN
 			excluded                                   *string
 			interval                                   *string
 			options                                    *string
-			secretName, secretValue                    *string
-			reqSrc, reqCommit                          *string
-			reqPath, reqPrefix                         sql.Null[string]
-			reqOpts                                    sql.Null[string] // JSON
 		}
 		bundleMap := make(map[string]*config.Bundle)
 		idMap := make(map[string]int64)
@@ -838,28 +814,14 @@ LEFT JOIN
 				&row.filepath,
 				&row.excluded,
 				&row.interval,
-				&row.options,
-				&row.secretName, &row.secretValue,
-				&row.reqSrc,
-				&row.reqPath, &row.reqPrefix,
-				&row.reqOpts,
-				&row.reqCommit); err != nil {
+				&row.options); err != nil {
 				return nil, "", err
 			}
 
-			var s *config.Secret
-			if row.secretName != nil {
-				s = &config.Secret{Name: *row.secretName}
-				if err := json.Unmarshal([]byte(*row.secretValue), &s.Value); err != nil {
-					return nil, "", err
-				}
+			bundle := &config.Bundle{
+				Name: row.bundleName,
 			}
-
-			bundle, exists := bundleMap[row.bundleName]
-			if !exists {
-				bundle = &config.Bundle{
-					Name: row.bundleName,
-				}
+			{
 
 				if row.labels != nil {
 					if err := json.Unmarshal([]byte(*row.labels), &bundle.Labels); err != nil {
@@ -888,10 +850,6 @@ LEFT JOIN
 						bundle.ObjectStorage.AmazonS3.URL = *row.s3url
 					}
 
-					if s != nil {
-						bundle.ObjectStorage.AmazonS3.Credentials = s.Ref()
-					}
-
 				} else if row.gcpProject != nil && row.s3bucket != nil && row.gcpObject != nil {
 					bundle.ObjectStorage.GCPCloudStorage = &config.GCPCloudStorage{
 						Project: *row.gcpProject,
@@ -899,19 +857,11 @@ LEFT JOIN
 						Object:  *row.gcpObject,
 					}
 
-					if s != nil {
-						bundle.ObjectStorage.GCPCloudStorage.Credentials = s.Ref()
-					}
-
 				} else if row.azureAccountURL != nil && row.azureContainer != nil && row.azurePath != nil {
 					bundle.ObjectStorage.AzureBlobStorage = &config.AzureBlobStorage{
 						AccountURL: *row.azureAccountURL,
 						Container:  *row.azureContainer,
 						Path:       *row.azurePath,
-					}
-
-					if s != nil {
-						bundle.ObjectStorage.AzureBlobStorage.Credentials = s.Ref()
 					}
 
 				} else if row.filepath != nil {
@@ -935,12 +885,114 @@ LEFT JOIN
 				}
 			}
 
-			if row.reqSrc != nil {
+			if row.id > lastId {
+				lastId = row.id
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, "", err
+		}
+
+		// The credentials and requirements hang off the bundles selected above,
+		// matched by bundle id. Each is its own statement rather than a join: the
+		// ids are literals here, so the planner seeks on the leading primary-key
+		// column instead of estimating how many rows the bundle query returns and
+		// falling back to a hash join over the whole table.
+
+		var bundleArgs []any
+		byID := make(map[int64]*config.Bundle, len(idMap))
+		for name, id := range idMap {
+			bundleArgs = append(bundleArgs, id)
+			byID[id] = bundleMap[name]
+		}
+		idList := strings.Join(d.args(len(bundleArgs)), ", ")
+
+		if len(bundleArgs) > 0 {
+			rowsSecrets, err := txn.QueryContext(ctx, `SELECT
+		bundles_secrets.bundle_id,
+		secrets.name,
+		secrets.value
+	FROM bundles_secrets
+	JOIN secrets ON bundles_secrets.secret_id = secrets.id
+	WHERE bundles_secrets.bundle_id IN (`+idList+`)
+	`, bundleArgs...)
+			if err != nil {
+				return nil, "", err
+			}
+			defer rowsSecrets.Close()
+
+			for rowsSecrets.Next() {
+				var bundleID int64
+				var secretName string
+				var secretValue *string
+				if err := rowsSecrets.Scan(&bundleID, &secretName, &secretValue); err != nil {
+					return nil, "", err
+				}
+
+				bundle, ok := byID[bundleID]
+				if !ok {
+					continue
+				}
+
+				secret := config.Secret{Name: secretName}
+				if secretValue != nil {
+					if err := json.Unmarshal([]byte(*secretValue), &secret.Value); err != nil {
+						return nil, "", err
+					}
+				}
+
+				// Only one storage backend is populated per bundle, and the file
+				// system one takes no credentials.
+				switch {
+				case bundle.ObjectStorage.AmazonS3 != nil:
+					bundle.ObjectStorage.AmazonS3.Credentials = secret.Ref()
+				case bundle.ObjectStorage.GCPCloudStorage != nil:
+					bundle.ObjectStorage.GCPCloudStorage.Credentials = secret.Ref()
+				case bundle.ObjectStorage.AzureBlobStorage != nil:
+					bundle.ObjectStorage.AzureBlobStorage.Credentials = secret.Ref()
+				}
+			}
+			if err := rowsSecrets.Err(); err != nil {
+				return nil, "", err
+			}
+
+			rowsReqs, err := txn.QueryContext(ctx, `SELECT
+		bundles_requirements.bundle_id,
+		sources.name,
+		bundles_requirements.gitcommit,
+		bundles_requirements.path,
+		bundles_requirements.prefix,
+		bundles_requirements.options
+	FROM bundles_requirements
+	JOIN sources ON bundles_requirements.source_id = sources.id
+	WHERE bundles_requirements.bundle_id IN (`+idList+`)
+	ORDER BY bundles_requirements.bundle_id, bundles_requirements.source_id
+	`, bundleArgs...)
+			if err != nil {
+				return nil, "", err
+			}
+			defer rowsReqs.Close()
+
+			for rowsReqs.Next() {
+				var bundleID int64
+				var reqSrc string
+				var reqCommit *string
+				var reqPath, reqPrefix sql.Null[string]
+				var reqOpts sql.Null[string] // JSON
+				if err := rowsReqs.Scan(&bundleID, &reqSrc, &reqCommit, &reqPath, &reqPrefix, &reqOpts); err != nil {
+					return nil, "", err
+				}
+
+				bundle, ok := byID[bundleID]
+				if !ok {
+					continue
+				}
+
 				var automount *bool
-				if row.reqOpts.Valid {
+				if reqOpts.Valid {
 					var m map[string]any
-					if err := json.Unmarshal([]byte(row.reqOpts.V), &m); err != nil {
-						return nil, "", fmt.Errorf("failed to unmarshal options for requirement %s of bundle %s: %w", *row.reqSrc, bundle.Name, err)
+					if err := json.Unmarshal([]byte(reqOpts.V), &m); err != nil {
+						return nil, "", fmt.Errorf("failed to unmarshal options for requirement %s of bundle %s: %w", reqSrc, bundle.Name, err)
 					}
 					if am, ok := m["automount"]; ok {
 						if am, ok := am.(bool); ok {
@@ -949,25 +1001,21 @@ LEFT JOIN
 						}
 					}
 					if len(m) > 0 {
-						return nil, "", fmt.Errorf("unknown options for requirement %s of bundle %s: %v", *row.reqSrc, bundle.Name, m)
+						return nil, "", fmt.Errorf("unknown options for requirement %s of bundle %s: %v", reqSrc, bundle.Name, m)
 					}
-
 				}
+
 				bundle.Requirements = append(bundle.Requirements, config.Requirement{
-					Source:    row.reqSrc,
-					Git:       config.GitRequirement{Commit: row.reqCommit},
-					Path:      row.reqPath.V, // if null, use ""
-					Prefix:    row.reqPrefix.V,
+					Source:    &reqSrc,
+					Git:       config.GitRequirement{Commit: reqCommit},
+					Path:      reqPath.V, // if null, use ""
+					Prefix:    reqPrefix.V,
 					AutoMount: automount,
 				})
 			}
-
-			if row.id > lastId {
-				lastId = row.id
+			if err := rowsReqs.Err(); err != nil {
+				return nil, "", err
 			}
-		}
-		if err := rows.Err(); err != nil {
-			return nil, "", err
 		}
 
 		sl := slices.Collect(maps.Values(bundleMap))

--- a/internal/database/list_attached_rows_test.go
+++ b/internal/database/list_attached_rows_test.go
@@ -1,0 +1,118 @@
+package database_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+
+	internal_config "github.com/open-policy-agent/opa-control-plane/internal/config"
+	"github.com/open-policy-agent/opa-control-plane/internal/migrations"
+	"github.com/open-policy-agent/opa-control-plane/internal/test/dbs"
+	"github.com/open-policy-agent/opa-control-plane/pkg/config"
+)
+
+// TestListAttachedRows covers the attached rows of a bundle and a source now
+// that they load in statements of their own rather than through joins: the
+// requirements arrive exactly once each, and the storage credentials still land
+// on the bundle even though a separate statement fetches them.
+//
+// It also pins down the multiplication the joins made possible. Their result was
+// one row per secret times requirement, and the requirement rows were appended
+// per result row while only the first secret was applied. Today at most one
+// secret row can match -- UpsertBundle writes one, under whichever of the three
+// mutually exclusive storage backends is configured -- so the fan-out never
+// happened in practice. Keyed lookups remove the possibility rather than relying
+// on that.
+func TestListAttachedRows(t *testing.T) {
+	ctx := t.Context()
+
+	const (
+		tenant    = "fanout"
+		principal = "internal:fanout"
+	)
+
+	for databaseType, databaseConfig := range dbs.Configs(t) {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Parallel()
+			var ctr testcontainers.Container
+			if databaseConfig.Setup != nil {
+				ctr = databaseConfig.Setup(t)
+				t.Cleanup(databaseConfig.Cleanup(t, ctr))
+			}
+
+			db, err := migrations.New().WithConfig(databaseConfig.Database(t, ctr).Database).WithMigrate(true).Run(ctx)
+			require.NoError(t, err)
+			t.Cleanup(db.CloseDB)
+
+			require.NoError(t, db.UpsertTenantWithPrincipal(ctx, tenant, principal, "administrator"))
+
+			// Three sources to require, and a secret for the bundle's storage.
+			for _, name := range []string{"req-one", "req-two", "req-three"} {
+				require.NoError(t, db.UpsertSource(ctx, principal, tenant, &config.Source{
+					Name: name,
+					Git:  config.Git{Repo: "https://example.com/" + name},
+				}))
+			}
+			require.NoError(t, db.UpsertSecret(ctx, principal, tenant, &internal_config.Secret{
+				Name:  "storage-creds",
+				Value: map[string]any{"type": "aws", "access_key_id": "k", "secret_access_key": "s"},
+			}))
+
+			require.NoError(t, db.UpsertBundle(ctx, principal, tenant, &config.Bundle{
+				Name: "many",
+				ObjectStorage: config.ObjectStorage{
+					AmazonS3: &config.AmazonS3{
+						Region:      "us-east-1",
+						Bucket:      "b",
+						Key:         "k",
+						Credentials: &config.SecretRef{Name: "storage-creds"},
+					},
+				},
+				Requirements: []config.Requirement{
+					{Source: strPtr("req-one")},
+					{Source: strPtr("req-two")},
+					{Source: strPtr("req-three")},
+				},
+			}))
+
+			bundle, err := db.GetBundle(ctx, principal, tenant, "many")
+			require.NoError(t, err)
+
+			require.Len(t, bundle.Requirements, 3, "one entry per requirement, not one per requirement times secret")
+			names := make([]string, 0, len(bundle.Requirements))
+			for _, r := range bundle.Requirements {
+				require.NotNil(t, r.Source)
+				names = append(names, *r.Source)
+			}
+			assert.ElementsMatch(t, []string{"req-one", "req-two", "req-three"}, names)
+
+			require.NotNil(t, bundle.ObjectStorage.AmazonS3, "the storage backend survives the split load")
+			assert.Equal(t, "storage-creds", bundle.ObjectStorage.AmazonS3.Credentials.Name,
+				"credentials are attached even though they load in a separate statement")
+
+			// A source with several requirements has the same shape.
+			require.NoError(t, db.UpsertSource(ctx, principal, tenant, &config.Source{
+				Name: "requiring",
+				Git:  config.Git{Repo: "https://example.com/requiring"},
+				Requirements: []config.Requirement{
+					{Source: strPtr("req-one")},
+					{Source: strPtr("req-two")},
+				},
+			}))
+
+			source, err := db.GetSource(ctx, principal, tenant, "requiring")
+			require.NoError(t, err)
+			require.Len(t, source.Requirements, 2)
+			srcNames := make([]string, 0, len(source.Requirements))
+			for _, r := range source.Requirements {
+				require.NotNil(t, r.Source)
+				srcNames = append(srcNames, *r.Source)
+			}
+			assert.ElementsMatch(t, []string{"req-one", "req-two"}, srcNames)
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }


### PR DESCRIPTION
## Why

`ListSources` and `ListBundles` reached a row's attached data through LEFT JOINs hanging off a subquery. CockroachDB has to estimate how many rows that subquery returns before it can choose a join strategy, and with a `JOIN tenants` inside the subquery it guesses high and settles on a hash join — reading the joined tables in full.

From a production console, on the `ListSources` statement:

```
Full Scan                Yes
Average Rows Read        128.2      ← to return one source
Average Execution Time   276.9 ms
Execution Count (6h)     19.5 k

plan:
  scan sources_secrets@..._pkey        spans: FULL SCAN
  scan sources_requirements@..._pkey   spans: FULL SCAN
  scan secrets@..._pkey                spans: FULL SCAN
```

`GetSource` and `GetBundle` are these same functions with the name pinned, so **fetching one row scans three or four tables**. That path is not rare: `DeleteBundleConfig` calls `GetBundle` purely to return the deleted bundle to the caller.

Measured on that `GetBundle` statement from OTel spans:

| | duration |
|---|---|
| us-east-1f | **1.35–1.39s** |
| us-west-3k (co-located gateway) | **515.61ms / 520.97ms** |

Two independent measurements in the co-located region agree to 1%, so this is the scan, not the network.

## What changed

Select the rows first, then pass their ids as literals:

```diff
-FROM (SELECT … WHERE bundles.name = $2) AS bundles
-LEFT JOIN bundles_secrets      ON bundles.id = bundles_secrets.bundle_id
-LEFT JOIN secrets              ON bundles_secrets.secret_id = secrets.id
-LEFT JOIN bundles_requirements ON bundles.id = bundles_requirements.bundle_id
-LEFT JOIN sources              ON bundles_requirements.source_id = sources.id
+WHERE bundles_secrets.bundle_id      IN (42)
+WHERE bundles_requirements.bundle_id IN (42)
```

`bundle_id` and `source_id` are the leading primary-key column of each cross table, so with a literal there the planner seeks. There is nothing left to estimate, which also means the plan stops depending on how fresh the table statistics are or how large those tables grow.

This is the shape `a2919ea` already used for datasources; `ListSources` now shares one id list across all three follow-up statements.

One wrinkle in `ListBundles`: credentials now arrive after the bundle is constructed, so they're applied to whichever storage backend is populated rather than being set while it's built. Only one can be, and `FileSystemStorage` takes none.

## About the fan-out

The joined result was one row per secret × requirement. Requirements were appended per result row, and only the first secret was applied — so several matching secrets would have duplicated the requirements and dropped all but one credential.

**This never happened in practice, and I want to be precise about that.** At most one secret row can match today: `UpsertBundle` writes one, under whichever of the three mutually exclusive storage backends is configured, and the `ListSources` query filters `ref_type = 'git_credentials'`. So `1 × M` stayed `M`. The split removes the possibility rather than continuing to rely on that invariant holding.

## Testing

- [x] `TestListAttachedRows` (new) — a bundle with three requirements and storage credentials, and a source with two requirements; asserts each requirement appears exactly once and that credentials still land on the bundle despite loading in a separate statement
- [x] **Verified the new test fails on a broken assembly** — deliberately dropped the credentials write-back and it failed; restored and it passes. It isn't a test that passes either way.
- [x] `TestDatabase/sqlite-memory-only`, `/sqlite-persistence`, `TestListSourcesTenantScopesDatasources/sqlite-*` all pass
- [x] `go build ./...`, `go vet ./internal/database/...`, `gofmt` clean
- [ ] Postgres / MySQL / CockroachDB — **CI only**, see Notes
- [ ] Post-deploy: re-check rows read and duration on both statements

## Notes

⚠️ **I could not run the non-SQLite tests locally** — testcontainers needs Docker, which isn't available in my environment. This change touches dialect-sensitive ground (placeholder generation, `sql.Null[string]` scanning), and `a2919ea` was a case where CI caught a MySQL-only bug in this very function. Please don't merge on a green SQLite run alone.

⚠️ **More statements, less work.** Each list now issues 2–3 statements where it issued one. On a co-located gateway an extra round trip is single-digit ms against hundreds of ms of scanning, so this should be a clear win — but it is a real trade, and it gets worse the further the client sits from the gateway.

⚠️ **Requirement ordering is now explicit.** The joins left it to whatever order the join produced; the new statements add `ORDER BY … source_id` / `requirement_id`. Previously unspecified, now deterministic — no caller should depend on either, but worth knowing.

⚠️ **Overlaps with #418.** Both touch neighbouring parts of `database.go`. #418 is smaller and independent; I'd suggest landing it first and I'll rebase this.

⚠️ **`ListStacks` still uses joins.** Same shape, left alone here to keep the diff reviewable.
