### PR TITLE
database: bound the single-row getters to one row

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -117,6 +117,13 @@ func (d *Database) Dialect() (string, error) {
 }
 
 type ListOptions struct {
+	// Limit caps the number of rows returned, and is also how a caller that
+	// wants a single row says so. That matters beyond the row count: the
+	// planner cannot derive the bound itself, because tenant_id arrives
+	// through JOIN tenants rather than as a constant, so
+	// UNIQUE(tenant_id, name) does not tell it that a name matches at most
+	// one row. Left unbounded it plans for many and hash-joins the attached
+	// tables in full; given the bound it seeks.
 	Limit  int
 	Cursor string
 	name   string
@@ -692,7 +699,7 @@ func (d *Database) LoadConfig(ctx context.Context, bar *progress.Bar, principal,
 }
 
 func (d *Database) GetBundle(ctx context.Context, principal, tenant, name string) (*config.Bundle, error) {
-	bundles, _, err := d.ListBundles(ctx, principal, tenant, ListOptions{name: name})
+	bundles, _, err := d.ListBundles(ctx, principal, tenant, ListOptions{name: name, Limit: 1})
 	if err != nil {
 		return nil, err
 	}
@@ -985,7 +992,7 @@ LEFT JOIN
 }
 
 func (d *Database) GetSource(ctx context.Context, principal, tenant, name string) (*config.Source, error) {
-	sources, _, err := d.ListSources(ctx, principal, tenant, ListOptions{name: name})
+	sources, _, err := d.ListSources(ctx, principal, tenant, ListOptions{name: name, Limit: 1})
 	if err != nil {
 		return nil, err
 	}
@@ -1312,7 +1319,7 @@ WHERE (sources_secrets.ref_type = 'git_credentials' OR sources_secrets.ref_type 
 }
 
 func (d *Database) GetSecret(ctx context.Context, principal, tenant, name string) (*config.SecretRef, error) {
-	secrets, _, err := d.ListSecrets(ctx, principal, tenant, ListOptions{name: name})
+	secrets, _, err := d.ListSecrets(ctx, principal, tenant, ListOptions{name: name, Limit: 1})
 	if err != nil {
 		return nil, err
 	}
@@ -1410,7 +1417,7 @@ func (d *Database) ListSecrets(ctx context.Context, principal, tenant string, op
 }
 
 func (d *Database) GetStack(ctx context.Context, principal, tenant, name string) (*config.Stack, error) {
-	stacks, _, err := d.ListStacks(ctx, principal, tenant, ListOptions{name: name})
+	stacks, _, err := d.ListStacks(ctx, principal, tenant, ListOptions{name: name, Limit: 1})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Why

`GetBundle`, `GetSource`, `GetSecret` and `GetStack` are each a list with the name pinned:

```go
func (d *Database) GetBundle(ctx context.Context, principal, tenant, name string) (*config.Bundle, error) {
	bundles, _, err := d.ListBundles(ctx, principal, tenant, ListOptions{name: name})
	...
```

A name is unique per tenant, so at most one row can match. **But the planner can't work that out.** `tenant_id` reaches the query through `JOIN tenants` rather than as a constant, so `UNIQUE(tenant_id, name)` doesn't bound the result for it. Left unbounded it plans for many rows and hash-joins the attached tables in full — which is why fetching one bundle reads `bundles_secrets`, `secrets`, `bundles_requirements` and `sources` end to end.

**The same query with a `LIMIT` doesn't.** Two fingerprints of it exist in a production cluster, differing only by that clause:

```
... WHERE (_) AND (tenants.name = _) ORDER BY bundles.id            → Full Scan: Yes
... WHERE (_) AND (tenants.name = _) ORDER BY bundles.id LIMIT _    → no full scan
```

So the planner isn't misjudging anything — it's missing a bound that the caller can supply for free.

## What changed

Four call sites gain `Limit: 1`, and the reason lives on the `ListOptions.Limit` field rather than being repeated at each one:

```diff
-	bundles, _, err := d.ListBundles(ctx, principal, tenant, ListOptions{name: name})
+	bundles, _, err := d.ListBundles(ctx, principal, tenant, ListOptions{name: name, Limit: 1})
```

**The `LIMIT` lands on the subquery, not on the joined result.** `ListBundles` appends it to the `bundles` subquery, which is then wrapped as `FROM (…) AS bundles LEFT JOIN …` — so it caps how many *rows* are selected, not how many joined output rows come back. The picked row's attached secrets and requirements are still returned in full. I verified the generated SQL ends `… ORDER BY bundles.id LIMIT ?` inside the subquery.

`nextCursor` is now produced for these calls (`opts.Limit > 0 && len(sl) == opts.Limit`), but all four getters discard the cursor, so nothing observable changes.

## Testing

- [x] `go build ./...`, `gofmt` clean
- [x] `TestDatabase/sqlite-memory-only` and `/sqlite-persistence` pass — these drive all four getters
- [x] `TestListSourcesTenantScopesDatasources/sqlite-*` passes
- [x] `internal/server` and `pkg/...` show no failures beyond the Docker-dependent ones
- [x] Verified the generated SQL places `LIMIT` inside the subquery, after `ORDER BY`
- [ ] Postgres / MySQL / CockroachDB — **CI only**, see Notes
- [ ] Post-deploy: confirm the full scan is gone from the `Get*` fingerprints

## Notes

⚠️ **I could not run the non-SQLite tests locally** — testcontainers needs Docker, unavailable in my environment. SQLite's planner is not CockroachDB's, so the *effect* of this change is unverified here; only its correctness is. The plan improvement rests on the production observation above (two fingerprints, one with `LIMIT`, only the other full-scanning).

⚠️ **This does not help delete paths.** `GetBundle`/`GetSource` were also called by `DeleteBundleConfig`/`DeleteSource` purely to build a response body. Those reads are being removed outright rather than optimised, so this change is aimed at the endpoints that genuinely need to read a single resource.

⚠️ **Bounding it to 1 is a behavioural assertion.** If two rows could ever match a name within a tenant, this would silently return the lowest id instead of surfacing the ambiguity. `UNIQUE(tenant_id, name)` on each table makes that impossible today, and the getters already returned `bundles[0]` regardless, so the assumption isn't new — it's now stated to the database as well.
